### PR TITLE
Expose Offline Voice Input to SwiftKey + add a proper animation

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -40,6 +40,21 @@
             android:excludeFromRecents="true"
             android:launchMode="singleInstance"
             android:exported="false" />
+            
+        <!-- RecognizerIntent entry point (for SwiftKey chooser) -->
+        <activity
+            android:name=".RecognizeActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:launchMode="singleTask"
+            android:theme="@android:style/Theme.DeviceDefault.Dialog.NoActionBar">
+
+            <intent-filter>
+                <action android:name="android.speech.action.RECOGNIZE_SPEECH" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
 
         <!-- Live Subtitles Service -->
         <service

--- a/res/layout/recognize_activity.xml
+++ b/res/layout/recognize_activity.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#1F2937"
+    android:padding="24dp">
+
+    <!-- Close (discard) -->
+    <ImageButton
+        android:id="@+id/btn_close"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_gravity="top|end"
+        android:background="@android:color/transparent"
+        android:contentDescription="Close"
+        android:src="@android:drawable/ic_menu_close_clear_cancel"
+        android:tint="#FFFFFF" />
+
+    <!-- Center mic + ring -->
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center">
+
+        <dev.notune.transcribe.MicLevelView
+            android:id="@+id/mic_level"
+            android:layout_width="220dp"
+            android:layout_height="220dp"
+            android:layout_gravity="center" />
+
+        <ImageView
+            android:id="@+id/mic_icon"
+            android:layout_width="72dp"
+            android:layout_height="72dp"
+            android:layout_gravity="center"
+            android:src="@android:drawable/ic_btn_speak_now"
+            android:tint="#FFFFFF" />
+
+        <TextView
+            android:id="@+id/txt_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal|bottom"
+            android:layout_marginBottom="18dp"
+            android:text="Listening... (Tap to stop)"
+            android:textColor="#FFFFFF"
+            android:textSize="18sp" />
+    </FrameLayout>
+
+</FrameLayout>

--- a/src/ime.rs
+++ b/src/ime.rs
@@ -1,29 +1,11 @@
-use std::sync::{Arc, Mutex};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 use jni::JNIEnv;
-use jni::objects::{JClass, JObject, GlobalRef};
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use jni::objects::{JClass, JObject};
 use once_cell::sync::Lazy;
-use transcribe_rs::TranscriptionEngine;
 
-use crate::engine;
-use crate::assets;
+use crate::voice_session::{self, VoiceSessionState};
 
-/// Tracks whether the model is currently being loaded (true = loading in progress)
-static MODEL_LOADING: AtomicBool = AtomicBool::new(false);
-
-struct SendStream(#[allow(dead_code)] cpal::Stream);
-unsafe impl Send for SendStream {}
-unsafe impl Sync for SendStream {}
-
-struct ImeState {
-    stream: Option<SendStream>,
-    audio_buffer: Arc<Mutex<Vec<f32>>>,
-    jvm: Arc<jni::JavaVM>,
-    service_ref: GlobalRef,
-}
-
-static IME_STATE: Lazy<Mutex<Option<ImeState>>> = Lazy::new(|| Mutex::new(None));
+static IME_STATE: Lazy<Mutex<Option<VoiceSessionState>>> = Lazy::new(|| Mutex::new(None));
 
 #[no_mangle]
 pub unsafe extern "system" fn Java_dev_notune_transcribe_RustInputMethodService_initNative(
@@ -31,67 +13,8 @@ pub unsafe extern "system" fn Java_dev_notune_transcribe_RustInputMethodService_
     _class: JClass,
     service: JObject,
 ) {
-    android_logger::init_once(android_logger::Config::default().with_max_level(log::LevelFilter::Info));
-    let vm = env.get_java_vm().expect("Failed to get JavaVM");
-    let vm_arc = Arc::new(vm);
-    let service_ref = env.new_global_ref(&service).expect("Failed to ref service");
-    
-    let mut state_guard = IME_STATE.lock().unwrap();
-    *state_guard = Some(ImeState {
-        stream: None,
-        audio_buffer: Arc::new(Mutex::new(Vec::new())),
-        jvm: vm_arc.clone(),
-        service_ref: service_ref.clone(),
-    });
-    
-    // Trigger lazy loading of engine if needed, but for IME we usually wait for main app.
-    // However, if IME starts first (possible), we must ensure model is there.
-    let vm_clone = vm_arc.clone();
-    let service_ref_clone = service_ref.clone();
-    
-    std::thread::spawn(move || {
-        if !engine::is_engine_loaded() {
-            MODEL_LOADING.store(true, Ordering::Release);
-            if let Ok(mut env) = vm_clone.attach_current_thread() {
-                 let srv = service_ref_clone.as_obj();
-                 notify_status(&mut env, srv, "Loading model...");
-
-                 // Attempt extraction/loading
-                 match assets::extract_assets(&mut env, srv) {
-                     Ok(path) => {
-                         let mut eng = transcribe_rs::engines::parakeet::ParakeetEngine::new();
-                         match eng.load_model_with_params(&path, transcribe_rs::engines::parakeet::ParakeetModelParams::int8()) {
-                             Ok(_) => {
-                                 engine::set_engine(eng);
-                                 MODEL_LOADING.store(false, Ordering::Release);
-                                 notify_status(&mut env, srv, "Ready");
-                             },
-                             Err(e) => {
-                                 MODEL_LOADING.store(false, Ordering::Release);
-                                 notify_status(&mut env, srv, &format!("Error: {}", e));
-                             },
-                         }
-                     },
-                     Err(e) => {
-                         MODEL_LOADING.store(false, Ordering::Release);
-                         notify_status(&mut env, srv, &format!("Error: {}", e));
-                     },
-                 }
-            } else {
-                MODEL_LOADING.store(false, Ordering::Release);
-            }
-        } else {
-             if let Ok(mut env) = vm_clone.attach_current_thread() {
-                 notify_status(&mut env, service_ref_clone.as_obj(), "Ready");
-             }
-        }
-    });
-}
-
-fn notify_status(env: &mut JNIEnv, obj: &JObject, msg: &str) {
-    if let Ok(jmsg) = env.new_string(msg) {
-        let _ = env.call_method(obj, "onStatusUpdate", "(Ljava/lang/String;)V", &[(&jmsg).into()]);
-    }
+    let state = voice_session::init_session(env, service);
+    *IME_STATE.lock().unwrap() = Some(state);
 }
 
 #[no_mangle]
@@ -104,95 +27,22 @@ pub unsafe extern "system" fn Java_dev_notune_transcribe_RustInputMethodService_
 
 #[no_mangle]
 pub unsafe extern "system" fn Java_dev_notune_transcribe_RustInputMethodService_startRecording(
-    mut env: JNIEnv,
+    env: JNIEnv,
     _class: JClass,
 ) {
-    let mut state_guard = IME_STATE.lock().unwrap();
-    if let Some(state) = state_guard.as_mut() {
-         let host = cpal::default_host();
-         let device = match host.default_input_device() {
-             Some(d) => d,
-             None => return,
-         };
-         
-         let config = cpal::StreamConfig {
-            channels: 1,
-            sample_rate: cpal::SampleRate(16000),
-            buffer_size: cpal::BufferSize::Default,
-         };
-         
-         state.audio_buffer.lock().unwrap().clear();
-         let buffer_clone = state.audio_buffer.clone();
-         
-         let stream = device.build_input_stream(
-             &config,
-             move |data: &[f32], _: &_| {
-                 buffer_clone.lock().unwrap().extend_from_slice(data);
-             },
-             |e| log::error!("Stream err: {}", e),
-             None,
-         );
-         
-         if let Ok(s) = stream {
-             s.play().ok();
-             state.stream = Some(SendStream(s));
-             notify_status(&mut env, state.service_ref.as_obj(), "Listening...");
-         }
+    let mut guard = IME_STATE.lock().unwrap();
+    if let Some(state) = guard.as_mut() {
+        voice_session::start_recording(env, state);
     }
 }
 
 #[no_mangle]
 pub unsafe extern "system" fn Java_dev_notune_transcribe_RustInputMethodService_stopRecording(
-    mut env: JNIEnv,
+    env: JNIEnv,
     _class: JClass,
 ) {
-    let (buffer, jvm, service_ref) = {
-        let mut state_guard = IME_STATE.lock().unwrap();
-        if let Some(state) = state_guard.as_mut() {
-            state.stream = None;
-            (state.audio_buffer.lock().unwrap().clone(), state.jvm.clone(), state.service_ref.clone())
-        } else {
-            return;
-        }
-    };
-    
-    notify_status(&mut env, service_ref.as_obj(), "Transcribing...");
-
-    std::thread::spawn(move || {
-        let mut env = jvm.attach_current_thread().unwrap();
-        let service_obj = service_ref.as_obj();
-
-        // If engine not ready, wait for model to finish loading
-        if engine::get_engine().is_none() && MODEL_LOADING.load(Ordering::Acquire) {
-            notify_status(&mut env, service_obj, "Waiting for model...");
-            let start = std::time::Instant::now();
-            while engine::get_engine().is_none() && MODEL_LOADING.load(Ordering::Acquire) {
-                if start.elapsed() > std::time::Duration::from_secs(120) {
-                    notify_status(&mut env, service_obj, "Error: timeout waiting for model");
-                    return;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(200));
-            }
-        }
-
-        let engine_opt = engine::get_engine();
-        if let Some(eng_arc) = engine_opt {
-             let res = {
-                 let mut eng = eng_arc.lock().unwrap();
-                 eng.transcribe_samples(buffer, None)
-             };
-             
-             match res {
-                Ok(r) => {
-                    notify_status(&mut env, service_obj, "Ready");
-                    if let Ok(txt) = env.new_string(r.text) {
-                        let _ = env.call_method(service_obj, "onTextTranscribed", "(Ljava/lang/String;)V", &[(&txt).into()]);
-                    }
-                },
-                Err(e) => notify_status(&mut env, service_obj, &format!("Error: {}", e)),
-            }
-        } else {
-            notify_status(&mut env, service_obj, "Error: model failed to load");
-        }
-    });
+    let mut guard = IME_STATE.lock().unwrap();
+    if let Some(state) = guard.as_mut() {
+        voice_session::stop_recording(env, state);
+    }
 }

--- a/src/java/dev/notune/transcribe/MicLevelView.java
+++ b/src/java/dev/notune/transcribe/MicLevelView.java
@@ -1,0 +1,72 @@
+package dev.notune.transcribe;
+
+import android.animation.ValueAnimator;
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.util.AttributeSet;
+import android.view.View;
+
+public class MicLevelView extends View {
+
+    private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private float current = 0f;   // 0..1
+    private float target = 0f;    // 0..1
+    private ValueAnimator animator;
+
+    public MicLevelView(Context c) { super(c); init(); }
+    public MicLevelView(Context c, AttributeSet a) { super(c, a); init(); }
+    public MicLevelView(Context c, AttributeSet a, int s) { super(c, a, s); init(); }
+
+    private void init() {
+        paint.setStyle(Paint.Style.FILL);
+        paint.setColor(0xFFFFFFFF); // weiß, Alpha setzen wir dynamisch
+    }
+
+
+    private float dp(float v) {
+        return v * getResources().getDisplayMetrics().density;
+    }
+
+    /** level: 0..1 */
+    public void setLevel(float level) {
+        if (level < 0f) level = 0f;
+        if (level > 1f) level = 1f;
+        target = level;
+
+        if (animator != null) animator.cancel();
+        animator = ValueAnimator.ofFloat(current, target);
+        animator.setDuration(60); // schnell, wirkt „live“
+        animator.addUpdateListener(a -> {
+            current = (float) a.getAnimatedValue();
+            invalidate();
+        });
+        animator.start();
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+
+        float cx = getWidth() / 2f;
+        float cy = getHeight() / 2f;
+        float min = Math.min(getWidth(), getHeight()) / 2f;
+
+        // Radius: Grundgröße + Pegel
+        float base = min * 0.42f;
+        float extra = min * 0.28f * current;
+        float r = base + extra;
+
+        // Innerer heller Kreis (macht Mitte heller)
+        int alphaInner = (int) (50 + 90 * current);  // 50..140
+        paint.setAlpha(alphaInner);
+        canvas.drawCircle(cx, cy, r, paint);
+
+        // Äußerer weicher Glow (größer, transparenter)
+        int alphaOuter = (int) (18 + 45 * current);  // 18..63
+        paint.setAlpha(alphaOuter);
+        canvas.drawCircle(cx, cy, r * 1.25f, paint);
+    }
+
+
+}

--- a/src/java/dev/notune/transcribe/RecognizeActivity.java
+++ b/src/java/dev/notune/transcribe/RecognizeActivity.java
@@ -1,0 +1,117 @@
+package dev.notune.transcribe;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.speech.RecognizerIntent;
+import android.util.Log;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.content.pm.PackageManager;
+
+import java.util.ArrayList;
+
+public class RecognizeActivity extends Activity {
+
+    private static final String TAG = "OfflineVoiceInput";
+
+    static {
+        try {
+            System.loadLibrary("c++_shared");
+            System.loadLibrary("onnxruntime");
+            System.loadLibrary("android_transcribe_app");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native libraries", e);
+        }
+    }
+
+    private TextView status;
+    private boolean isRecording = false;
+    private MicLevelView micLevel;
+
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.recognize_activity);
+
+        micLevel = findViewById(R.id.mic_level);
+        status = findViewById(R.id.txt_status);
+
+        findViewById(R.id.btn_close).setOnClickListener(v -> {
+            // discard current recording
+            if (isRecording) {
+                isRecording = false;
+                cancelRecording();   // new native method
+            }
+            setResult(Activity.RESULT_CANCELED);
+            finish();
+        });
+
+        // Tap anywhere (or on mic) to stop
+        findViewById(R.id.root).setOnClickListener(v -> {
+            if (isRecording) {
+                isRecording = false;
+                status.setText("Processing...");
+                stopRecording();
+            }
+        });
+
+        // Permission check wie bisher...
+        // initNative(this), startRecording()
+
+        initNative(this);
+        isRecording = true;
+        status.setText("Listening... (Tap to stop)");
+        startRecording();
+    }    
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        try { cleanupNative(); } catch (Throwable t) { /* ignore */ }
+    }
+
+    // Called from Rust
+    public void onStatusUpdate(String s) {
+        final String shown;
+        if ("Ready".equals(s)) {
+            shown = "Ready (Tap to stop)";
+        } else if ("Listening...".equals(s)) {
+            shown = "Listening... (Tap to stop)";
+        } else {
+            shown = s;
+        }
+
+        runOnUiThread(() -> status.setText(shown));
+    }
+
+    
+    // Called from Rust with 0..1
+    public void onAudioLevel(float level) {
+        runOnUiThread(() -> micLevel.setLevel(level));
+    }
+
+    // Called from Rust – keep same method name as IME for code reuse
+    public void onTextTranscribed(String text) {
+        runOnUiThread(() -> {
+            ArrayList<String> results = new ArrayList<>();
+            results.add(text);
+
+            Intent data = new Intent();
+            data.putStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS, results);
+
+            setResult(Activity.RESULT_OK, data);
+            finish();
+        });
+    }
+    
+    // Native methods
+    private native void initNative(RecognizeActivity activity);
+    private native void cleanupNative();
+    private native void startRecording();
+    private native void stopRecording();
+    private native void cancelRecording();
+}

--- a/src/java/dev/notune/transcribe/RustInputMethodService.java
+++ b/src/java/dev/notune/transcribe/RustInputMethodService.java
@@ -323,4 +323,5 @@ public class RustInputMethodService extends InputMethodService {
             }
         });
     }
+    public void onAudioLevel(float level) { }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,5 @@ pub mod assets;
 pub mod ime;
 pub mod subtitle;
 pub mod main_activity;
+pub mod voice_session;
+pub mod recognize;

--- a/src/recognize.rs
+++ b/src/recognize.rs
@@ -1,0 +1,61 @@
+use std::sync::Mutex;
+
+use jni::JNIEnv;
+use jni::objects::{JClass, JObject};
+use once_cell::sync::Lazy;
+
+use crate::voice_session::{self, VoiceSessionState};
+
+static RECOG_STATE: Lazy<Mutex<Option<VoiceSessionState>>> = Lazy::new(|| Mutex::new(None));
+
+#[no_mangle]
+pub unsafe extern "system" fn Java_dev_notune_transcribe_RecognizeActivity_initNative(
+    env: JNIEnv,
+    _class: JClass,
+    activity: JObject,
+) {
+    let state = voice_session::init_session(env, activity);
+    *RECOG_STATE.lock().unwrap() = Some(state);
+}
+
+#[no_mangle]
+pub unsafe extern "system" fn Java_dev_notune_transcribe_RecognizeActivity_cleanupNative(
+    _env: JNIEnv,
+    _class: JClass,
+) {
+    *RECOG_STATE.lock().unwrap() = None;
+}
+
+#[no_mangle]
+pub unsafe extern "system" fn Java_dev_notune_transcribe_RecognizeActivity_startRecording(
+    env: JNIEnv,
+    _class: JClass,
+) {
+    let mut guard = RECOG_STATE.lock().unwrap();
+    if let Some(state) = guard.as_mut() {
+        voice_session::start_recording(env, state);
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "system" fn Java_dev_notune_transcribe_RecognizeActivity_stopRecording(
+    env: JNIEnv,
+    _class: JClass,
+) {
+    let mut guard = RECOG_STATE.lock().unwrap();
+    if let Some(state) = guard.as_mut() {
+        voice_session::stop_recording(env, state);
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "system" fn Java_dev_notune_transcribe_RecognizeActivity_cancelRecording(
+    env: JNIEnv,
+    _class: JClass,
+) {
+    let mut guard = RECOG_STATE.lock().unwrap();
+    if let Some(state) = guard.as_mut() {
+        crate::voice_session::cancel_recording(env, state);
+    }
+}
+

--- a/src/voice_session.rs
+++ b/src/voice_session.rs
@@ -1,0 +1,219 @@
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use jni::JNIEnv;
+use jni::objects::{GlobalRef, JObject};
+use transcribe_rs::TranscriptionEngine;
+
+use crate::{assets, engine};
+
+/// Shared flag for model loading across IME + RecognizeActivity
+static MODEL_LOADING: AtomicBool = AtomicBool::new(false);
+
+pub struct SendStream(#[allow(dead_code)] pub cpal::Stream);
+unsafe impl Send for SendStream {}
+unsafe impl Sync for SendStream {}
+
+pub struct VoiceSessionState {
+    pub stream: Option<SendStream>,
+    pub audio_buffer: Arc<Mutex<Vec<f32>>>,
+    pub jvm: Arc<jni::JavaVM>,
+    pub target_ref: GlobalRef,
+    pub last_level_sent: Arc<Mutex<std::time::Instant>>,
+}
+
+fn notify_status(env: &mut JNIEnv, obj: &JObject, msg: &str) {
+    if let Ok(jmsg) = env.new_string(msg) {
+        let _ = env.call_method(obj, "onStatusUpdate", "(Ljava/lang/String;)V", &[(&jmsg).into()]);
+    }
+}
+
+fn notify_level(env: &mut JNIEnv, obj: &JObject, level: f32) {
+    let _ = env.call_method(obj, "onAudioLevel", "(F)V", &[level.into()]);
+}
+
+
+fn notify_text(env: &mut JNIEnv, obj: &JObject, text: &str) {
+    if let Ok(jtxt) = env.new_string(text) {
+        let _ = env.call_method(obj, "onTextTranscribed", "(Ljava/lang/String;)V", &[(&jtxt).into()]);
+    }
+}
+
+pub fn init_session(env: JNIEnv, target: JObject) -> VoiceSessionState {
+    android_logger::init_once(android_logger::Config::default().with_max_level(log::LevelFilter::Info));
+
+    let vm = env.get_java_vm().expect("Failed to get JavaVM");
+    let vm_arc = Arc::new(vm);
+    let target_ref = env.new_global_ref(&target).expect("Failed to ref target");
+
+    let state = VoiceSessionState {
+        stream: None,
+        audio_buffer: Arc::new(Mutex::new(Vec::new())),
+        jvm: vm_arc.clone(),
+        target_ref: target_ref.clone(),
+        last_level_sent: Arc::new(Mutex::new(std::time::Instant::now())),
+    };
+
+    // Ensure engine loaded (shared for both entry points)
+    let vm_clone = vm_arc.clone();
+    let target_ref_clone = target_ref.clone();
+
+    std::thread::spawn(move || {
+        if !engine::is_engine_loaded() {
+            MODEL_LOADING.store(true, Ordering::Release);
+
+            if let Ok(mut env) = vm_clone.attach_current_thread() {
+                let obj = target_ref_clone.as_obj();
+                notify_status(&mut env, obj, "Loading model...");
+
+                match assets::extract_assets(&mut env, obj) {
+                    Ok(path) => {
+                        let mut eng = transcribe_rs::engines::parakeet::ParakeetEngine::new();
+                        match eng.load_model_with_params(
+                            &path,
+                            transcribe_rs::engines::parakeet::ParakeetModelParams::int8()
+                        ) {
+                            Ok(_) => {
+                                engine::set_engine(eng);
+                                MODEL_LOADING.store(false, Ordering::Release);
+                                notify_status(&mut env, obj, "Ready");
+                            }
+                            Err(e) => {
+                                MODEL_LOADING.store(false, Ordering::Release);
+                                notify_status(&mut env, obj, &format!("Error: {}", e));
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        MODEL_LOADING.store(false, Ordering::Release);
+                        notify_status(&mut env, obj, &format!("Error: {}", e));
+                    }
+                }
+            } else {
+                MODEL_LOADING.store(false, Ordering::Release);
+            }
+        } else {
+            if let Ok(mut env) = vm_clone.attach_current_thread() {
+                notify_status(&mut env, target_ref_clone.as_obj(), "Ready");
+            }
+        }
+    });
+
+    state
+}
+
+pub fn start_recording(mut env: JNIEnv, state: &mut VoiceSessionState) {
+    let host = cpal::default_host();
+    let device = match host.default_input_device() {
+        Some(d) => d,
+        None => {
+            notify_status(&mut env, state.target_ref.as_obj(), "Error: no input device");
+            return;
+        }
+    };
+
+    let config = cpal::StreamConfig {
+        channels: 1,
+        sample_rate: cpal::SampleRate(16000),
+        buffer_size: cpal::BufferSize::Default,
+    };
+
+    state.audio_buffer.lock().unwrap().clear();
+    let buffer_clone = state.audio_buffer.clone();
+        
+    let jvm = state.jvm.clone();
+    let target_ref = state.target_ref.clone();
+    let last_sent = state.last_level_sent.clone();    
+
+    let stream = device.build_input_stream(
+        &config,
+        move |data: &[f32], _: &_| {
+            buffer_clone.lock().unwrap().extend_from_slice(data);
+			
+			// compute RMS
+			let mut sum = 0.0f32;
+			for &x in data {
+				sum += x * x;
+			}
+			let rms = (sum / (data.len() as f32)).sqrt();
+			let level = (rms * 6.0).clamp(0.0, 1.0);
+
+			// throttle updates
+			let mut last = last_sent.lock().unwrap();
+			if last.elapsed() >= std::time::Duration::from_millis(50) {
+				*last = std::time::Instant::now();
+
+				if let Ok(mut env) = jvm.attach_current_thread() {
+					let obj = target_ref.as_obj();
+					notify_level(&mut env, obj, level);
+				}
+			}            
+        },
+        |e| log::error!("Stream err: {}", e),
+        None,
+    );
+
+    match stream {
+        Ok(s) => {
+            s.play().ok();
+            state.stream = Some(SendStream(s));
+            notify_status(&mut env, state.target_ref.as_obj(), "Listening...");
+        }
+        Err(e) => {
+            notify_status(&mut env, state.target_ref.as_obj(), &format!("Error: {}", e));
+        }
+    }
+}
+
+pub fn stop_recording(mut env: JNIEnv, state: &mut VoiceSessionState) {
+    state.stream = None;
+
+    let buffer = state.audio_buffer.lock().unwrap().clone();
+    let jvm = state.jvm.clone();
+    let target_ref = state.target_ref.clone();
+
+    notify_status(&mut env, target_ref.as_obj(), "Transcribing...");
+
+    std::thread::spawn(move || {
+        let mut env = jvm.attach_current_thread().unwrap();
+        let obj = target_ref.as_obj();
+
+        // Wait for model if loading
+        if engine::get_engine().is_none() && MODEL_LOADING.load(Ordering::Acquire) {
+            notify_status(&mut env, obj, "Waiting for model...");
+            let start = std::time::Instant::now();
+            while engine::get_engine().is_none() && MODEL_LOADING.load(Ordering::Acquire) {
+                if start.elapsed() > std::time::Duration::from_secs(120) {
+                    notify_status(&mut env, obj, "Error: timeout waiting for model");
+                    return;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(200));
+            }
+        }
+
+        if let Some(eng_arc) = engine::get_engine() {
+            let res = {
+                let mut eng = eng_arc.lock().unwrap();
+                eng.transcribe_samples(buffer, None)
+            };
+
+            match res {
+                Ok(r) => {
+                    notify_status(&mut env, obj, "Ready");
+                    notify_text(&mut env, obj, &r.text);
+                }
+                Err(e) => notify_status(&mut env, obj, &format!("Error: {}", e)),
+            }
+        } else {
+            notify_status(&mut env, obj, "Error: model failed to load");
+        }
+    });
+}
+
+pub fn cancel_recording(mut env: JNIEnv, state: &mut VoiceSessionState) {
+    state.stream = None;
+    state.audio_buffer.lock().unwrap().clear();
+    notify_status(&mut env, state.target_ref.as_obj(), "Canceled");
+}
+


### PR DESCRIPTION
This PR updates the IME subtype definition to be recognized by keyboards such as SwiftKey by marking the voice subtype as an auxiliary voice IME (and aligning related subtype metadata). As a result, Offline Voice Input becomes selectable as a voice input option after switching from SwiftKey.

Additionally, this PR replaces the previous temporary placeholder UI with a proper animation to provide clearer feedback and a more polished user experience during voice input.

This addresses https://github.com/notune/android_transcribe_app/issues/3