### PR TITLE
Improve German number normalization for Parakeet output

### DIFF
--- a/transcribe-rs/Cargo.toml
+++ b/transcribe-rs/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1.47.1", features = ["rt-multi-thread"] }
 async-openai = { version = "0.29.3" }
 async-trait = { version = "0.1.89" }
 derive_builder = { version = "0.20.2" }
+text2num = "2.6.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 whisper-rs = { version = "0.13.2", features = ["metal"] }


### PR DESCRIPTION
## Improve German number normalization for Parakeet output

TL;DR

After extensive testing, this PR significantly improves number handling and overall usability for offline voice input.

This PR improves post-processing of German Parakeet transcriptions in `transcribe-rs` to make spoken numbers more usable in normal text output.

### Why this was needed

Parakeet sometimes returns German numbers as words (for example years or times), and it can also split German number words across tokens in ways that make direct conversion harder (e.g. forms like `neunzehnhundert siebenundvierzig`).

This led to inconsistent output such as:

* years were usually written as words instead of digits
* time phrases like `19 uhr fünf` not being converted cleanly
* mixed formatting depending on context (`18:45` in one case, but `18.05 Uhr` in another)

### What this PR changes

* Adds German number-word normalization using `text2num`
* Joins ASR-split German number word fragments in a conservative way (especially around scale words like `hundert` / `tausend`)
* Applies a conservative default conversion pass that reduces conversion of small isolated numbers (1–12), while still converting larger number expressions
* Applies additional local normalization in time/date contexts (e.g. `uhr`, month names) so forms like `19 uhr fünf` can become `19:05`
* Normalizes German dotted time output in `... Uhr` contexts (`18.05 Uhr` → `18:05 Uhr`)

### Why `.` is converted to `:` in time expressions

In some cases, number normalization can produce dotted time notation such as `18.05 Uhr`. While this is understandable, the rest of the output pipeline and many UI contexts expect colon-separated times (`18:05` / `18:05 Uhr`). This PR normalizes dotted `Uhr` times to colon format for consistency and better downstream handling.

### Notes

* The conversion is intentionally conservative in general text to avoid over-normalizing small standalone numbers in regular prose.
* In practice, small digits (1–12) may still appear as digits in some contexts (for example `10 Birnen`), depending on model output and context-sensitive normalization behavior.