### PR TITLE
Add accessible layout option for switch-keyboard button

### DIFF
--- a/app/src/main/java/dev/notune/transcribe/MainActivity.java
+++ b/app/src/main/java/dev/notune/transcribe/MainActivity.java
@@ -86,6 +86,7 @@ public class MainActivity extends AppCompatActivity {
         // Record-in-background defaults to ON; its marker file is the opt-out.
         bindMarkerSwitch(R.id.switch_record_background, "stop_on_hide", true);
         bindMarkerSwitch(R.id.switch_auto_stop, "auto_stop", false);
+        bindMarkerSwitch(R.id.switch_accessible_layout, "accessible_layout", false);
 
         // Live subtitle line limit: 2 (default), 4, or 0 = unlimited.
         RadioGroup subsLinesGroup = findViewById(R.id.rg_subtitle_lines);

--- a/app/src/main/java/dev/notune/transcribe/RustInputMethodService.java
+++ b/app/src/main/java/dev/notune/transcribe/RustInputMethodService.java
@@ -123,6 +123,18 @@ public class RustInputMethodService extends InputMethodService {
             enterButton = view.findViewById(R.id.ime_enter);
             switchKeyboardButton = view.findViewById(R.id.ime_switch_keyboard);
 
+            if (new File(getFilesDir(), "accessible_layout").exists()) {
+                LinearLayout bottomRow = (LinearLayout) switchKeyboardButton.getParent();
+                bottomRow.removeView(switchKeyboardButton);
+                LinearLayout statusRow = view.findViewById(R.id.ime_status_row);
+                float dp = view.getResources().getDisplayMetrics().density;
+                LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(0, (int) (44 * dp));
+                lp.weight = 1;
+                lp.setMarginStart((int) (8 * dp));
+                switchKeyboardButton.setLayoutParams(lp);
+                statusRow.addView(switchKeyboardButton);
+            }
+
             switchKeyboardButton.setOnClickListener(v -> {
                 if (isRecording) {
                     pendingSwitchBack = true;

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -423,6 +423,42 @@
                             android:layout_height="wrap_content"/>
                     </LinearLayout>
 
+                    <!-- Accessible keyboard layout -->
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:layout_marginTop="16dp">
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:orientation="vertical"
+                            android:layout_marginEnd="16dp">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/setting_accessible_layout"
+                                android:textAppearance="?attr/textAppearanceBodyLarge"/>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/setting_accessible_layout_desc"
+                                android:textAppearance="?attr/textAppearanceBodySmall"
+                                android:textColor="?attr/colorOnSurfaceVariant"
+                                android:layout_marginTop="2dp"/>
+                        </LinearLayout>
+
+                        <com.google.android.material.materialswitch.MaterialSwitch
+                            android:id="@+id/switch_accessible_layout"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"/>
+                    </LinearLayout>
+
                     <!-- Subtitle line count -->
                     <LinearLayout
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/ime_layout.xml
+++ b/app/src/main/res/layout/ime_layout.xml
@@ -9,6 +9,7 @@
 
     <!-- Status row -->
     <LinearLayout
+        android:id="@+id/ime_status_row"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,9 @@
     <string name="setting_auto_stop">Auto-stop after silence</string>
     <string name="setting_auto_stop_desc">End the voice input popup automatically ~2 seconds after you stop speaking</string>
 
+    <string name="setting_accessible_layout">Accessible keyboard layout</string>
+    <string name="setting_accessible_layout_desc">Move the keyboard-switch button to the top right for easier one-handed access</string>
+
     <string name="setting_subtitle_lines">Subtitle length</string>
     <string name="setting_subtitle_lines_desc">How many lines the live subtitles show; older text scrolls away</string>
     <string name="subtitle_lines_2">2 lines</string>


### PR DESCRIPTION
Adds a toggle in Settings that moves the switch-keyboard button from the bottom-left corner to the top-right status row, making it reachable for users with limited hand mobility or one-handed use.

Closes #55 