### PR TITLE
Add floating voice input, local history, and custom words

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,12 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
+
     // Source sets — the Rust-built .so files land in jniLibs via cargo-ndk
     sourceSets {
         getByName("main") {
@@ -92,6 +98,10 @@ dependencies {
         implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22")
         implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22")
     }
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.robolectric:robolectric:4.12.2")
+    testImplementation("androidx.test:core:1.5.0")
 }
 
 // ---------------------------------------------------------------------------

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
@@ -128,6 +129,39 @@
                 android:name="android.view.im"
                 android:resource="@xml/method" />
         </service>
+
+        <!-- Floating mic bubble service -->
+        <service
+            android:name=".BubbleService"
+            android:foregroundServiceType="microphone"
+            android:exported="false" />
+
+        <!-- Accessibility service for optional direct text insertion -->
+        <service
+            android:name=".InsertionAccessibilityService"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/accessibility_insertion" />
+        </service>
+
+        <!-- Transcription history -->
+        <activity
+            android:name=".HistoryActivity"
+            android:label="@string/history_title"
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:exported="false" />
+
+        <!-- Custom words (Whisper recognition bias) -->
+        <activity
+            android:name=".CustomWordsActivity"
+            android:label="@string/custom_words_title"
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:exported="false" />
 
     </application>
 </manifest>

--- a/app/src/main/java/dev/notune/transcribe/BubblePrefs.java
+++ b/app/src/main/java/dev/notune/transcribe/BubblePrefs.java
@@ -1,0 +1,77 @@
+package dev.notune.transcribe;
+
+import android.content.Context;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+public final class BubblePrefs {
+    private static final String POS_X_FILE = "bubble_x";
+    private static final String POS_Y_FILE = "bubble_y";
+    private static final String ENABLED_FILE = "bubble_enabled";
+    private static final String A11Y_CONSENT_FILE = "a11y_insertion_consent";
+
+    private BubblePrefs() {}
+
+    public static int getX(Context ctx) {
+        return readInt(ctx, POS_X_FILE, -1);
+    }
+
+    public static void setX(Context ctx, int x) {
+        writeInt(ctx, POS_X_FILE, x);
+    }
+
+    public static int getY(Context ctx) {
+        return readInt(ctx, POS_Y_FILE, -1);
+    }
+
+    public static void setY(Context ctx, int y) {
+        writeInt(ctx, POS_Y_FILE, y);
+    }
+
+    public static boolean isEnabled(Context ctx) {
+        return new File(ctx.getFilesDir(), ENABLED_FILE).exists();
+    }
+
+    public static void setEnabled(Context ctx, boolean enabled) {
+        File f = new File(ctx.getFilesDir(), ENABLED_FILE);
+        if (enabled) {
+            try { f.createNewFile(); } catch (IOException ignored) { }
+        } else {
+            f.delete();
+        }
+    }
+
+    public static boolean hasA11yConsent(Context ctx) {
+        return new File(ctx.getFilesDir(), A11Y_CONSENT_FILE).exists();
+    }
+
+    public static void setA11yConsent(Context ctx, boolean consent) {
+        File f = new File(ctx.getFilesDir(), A11Y_CONSENT_FILE);
+        if (consent) {
+            try { f.createNewFile(); } catch (IOException ignored) { }
+        } else {
+            f.delete();
+        }
+    }
+
+    private static int readInt(Context ctx, String name, int def) {
+        File f = new File(ctx.getFilesDir(), name);
+        if (!f.exists()) return def;
+        try {
+            return Integer.parseInt(
+                    new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8).trim());
+        } catch (IOException | NumberFormatException e) {
+            return def;
+        }
+    }
+
+    private static void writeInt(Context ctx, String name, int value) {
+        File f = new File(ctx.getFilesDir(), name);
+        try {
+            Files.write(f.toPath(), String.valueOf(value).getBytes(StandardCharsets.UTF_8));
+        } catch (IOException ignored) { }
+    }
+}

--- a/app/src/main/java/dev/notune/transcribe/BubblePrefs.java
+++ b/app/src/main/java/dev/notune/transcribe/BubblePrefs.java
@@ -12,6 +12,19 @@ public final class BubblePrefs {
     private static final String POS_Y_FILE = "bubble_y";
     private static final String ENABLED_FILE = "bubble_enabled";
     private static final String A11Y_CONSENT_FILE = "a11y_insertion_consent";
+    private static final String UNLOAD_MINUTES_FILE = "bubble_unload_minutes";
+    private static final String SIZE_DP_FILE = "bubble_size_dp";
+
+    /** Idle-unload choices offered in settings, in minutes. 0 = never. */
+    public static final int[] UNLOAD_MINUTES_CHOICES = {0, 5, 15, 30};
+    /** Default idle-unload interval for users who never changed the setting. */
+    public static final int DEFAULT_UNLOAD_MINUTES = 15;
+    /** Bubble diameter choices offered in settings, in dp. */
+    public static final int[] SIZE_DP_CHOICES = {48, 56, 72};
+    /** Default bubble diameter (also the minimum usable touch target). */
+    public static final int DEFAULT_SIZE_DP = 56;
+    /** Smallest diameter we allow; keeps a usable 48dp touch target. */
+    public static final int MIN_SIZE_DP = 48;
 
     private BubblePrefs() {}
 
@@ -55,6 +68,57 @@ public final class BubblePrefs {
         } else {
             f.delete();
         }
+    }
+
+    /**
+     * Idle-unload interval in minutes (0 = never). Absent setting yields the
+     * default; a stored value is snapped to the nearest offered choice so a
+     * hand-edited or stale file can't select an unsupported interval.
+     */
+    public static int getUnloadMinutes(Context ctx) {
+        return normalizeUnloadMinutes(readInt(ctx, UNLOAD_MINUTES_FILE, DEFAULT_UNLOAD_MINUTES));
+    }
+
+    public static void setUnloadMinutes(Context ctx, int minutes) {
+        writeInt(ctx, UNLOAD_MINUTES_FILE, normalizeUnloadMinutes(minutes));
+    }
+
+    /**
+     * Bubble diameter in dp. Absent setting yields the default; a stored value
+     * is snapped to the nearest offered choice and never below {@link
+     * #MIN_SIZE_DP}, keeping a usable touch target.
+     */
+    public static int getSizeDp(Context ctx) {
+        return normalizeSizeDp(readInt(ctx, SIZE_DP_FILE, DEFAULT_SIZE_DP));
+    }
+
+    public static void setSizeDp(Context ctx, int dp) {
+        writeInt(ctx, SIZE_DP_FILE, normalizeSizeDp(dp));
+    }
+
+    /** Snaps an arbitrary minute value to the nearest offered unload choice. */
+    static int normalizeUnloadMinutes(int minutes) {
+        return nearest(minutes, UNLOAD_MINUTES_CHOICES, DEFAULT_UNLOAD_MINUTES);
+    }
+
+    /** Snaps an arbitrary dp value to the nearest offered size, ≥ minimum. */
+    static int normalizeSizeDp(int dp) {
+        int chosen = nearest(dp, SIZE_DP_CHOICES, DEFAULT_SIZE_DP);
+        return Math.max(chosen, MIN_SIZE_DP);
+    }
+
+    private static int nearest(int value, int[] choices, int fallback) {
+        if (choices.length == 0) return fallback;
+        int best = choices[0];
+        int bestDist = Math.abs(value - best);
+        for (int i = 1; i < choices.length; i++) {
+            int dist = Math.abs(value - choices[i]);
+            if (dist < bestDist) {
+                best = choices[i];
+                bestDist = dist;
+            }
+        }
+        return best;
     }
 
     private static int readInt(Context ctx, String name, int def) {

--- a/app/src/main/java/dev/notune/transcribe/BubbleService.java
+++ b/app/src/main/java/dev/notune/transcribe/BubbleService.java
@@ -22,8 +22,10 @@ import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.widget.ImageView;
+import android.widget.ProgressBar;
 import android.widget.Toast;
 
 public class BubbleService extends Service {
@@ -31,6 +33,7 @@ public class BubbleService extends Service {
     public static final String ACTION_SHOW = "dev.notune.transcribe.BUBBLE_SHOW";
     public static final String ACTION_HIDE = "dev.notune.transcribe.BUBBLE_HIDE";
     public static final String ACTION_STOP_RECORDING = "dev.notune.transcribe.BUBBLE_STOP_REC";
+    public static final String ACTION_REFRESH = "dev.notune.transcribe.BUBBLE_REFRESH";
     private static final String CHANNEL_ID = "BubbleChannel";
     private static final int NOTIFICATION_ID = 23456;
 
@@ -46,15 +49,21 @@ public class BubbleService extends Service {
     private WindowManager mWindowManager;
     private View mBubbleView;
     private ImageView mBubbleIcon;
+    private ProgressBar mBubbleProgress;
+    private WindowManager.LayoutParams mParams;
     private Handler mMainHandler;
+    private Runnable mUnloadRunnable;
     private boolean isRecording = false;
     private boolean isProcessing = false;
+    private boolean isReloading = false;
+    private boolean isModelUnloaded = false;
 
     @Override
     public void onCreate() {
         super.onCreate();
         mMainHandler = new Handler(Looper.getMainLooper());
         mWindowManager = (WindowManager) getSystemService(WINDOW_SERVICE);
+        mUnloadRunnable = this::performIdleUnload;
         createNotificationChannel();
     }
 
@@ -90,6 +99,12 @@ public class BubbleService extends Service {
             if (isRecording) {
                 stopRecordingFlow();
             }
+        } else if (ACTION_REFRESH.equals(action)) {
+            // Settings (size / idle-unload interval) changed while visible.
+            if (mBubbleView != null) {
+                applyBubbleSize();
+                scheduleIdleUnload();
+            }
         }
         return START_NOT_STICKY;
     }
@@ -99,10 +114,11 @@ public class BubbleService extends Service {
 
         mBubbleView = LayoutInflater.from(this).inflate(R.layout.bubble_overlay, null);
         mBubbleIcon = mBubbleView.findViewById(R.id.bubble_icon);
+        mBubbleProgress = mBubbleView.findViewById(R.id.bubble_progress);
 
         int layoutFlag = WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
 
-        WindowManager.LayoutParams params = new WindowManager.LayoutParams(
+        mParams = new WindowManager.LayoutParams(
                 WindowManager.LayoutParams.WRAP_CONTENT,
                 WindowManager.LayoutParams.WRAP_CONTENT,
                 layoutFlag,
@@ -110,25 +126,29 @@ public class BubbleService extends Service {
                         | WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
                 PixelFormat.TRANSLUCENT);
 
-        params.gravity = Gravity.TOP | Gravity.START;
+        mParams.gravity = Gravity.TOP | Gravity.START;
         int savedX = BubblePrefs.getX(this);
         int savedY = BubblePrefs.getY(this);
         if (savedX >= 0 && savedY >= 0) {
-            params.x = savedX;
-            params.y = savedY;
+            mParams.x = savedX;
+            mParams.y = savedY;
         } else {
-            params.x = getResources().getDisplayMetrics().widthPixels - 160;
-            params.y = getResources().getDisplayMetrics().heightPixels / 3;
+            mParams.x = getResources().getDisplayMetrics().widthPixels - 160;
+            mParams.y = getResources().getDisplayMetrics().heightPixels / 3;
         }
 
-        mWindowManager.addView(mBubbleView, params);
+        mWindowManager.addView(mBubbleView, mParams);
+        applyBubbleSize();
         updateBubbleState();
-        makeDraggable(params);
+        makeDraggable();
 
         initNative(this);
+        isModelUnloaded = false;
+        scheduleIdleUnload();
     }
 
-    private void makeDraggable(WindowManager.LayoutParams params) {
+    private void makeDraggable() {
+        final WindowManager.LayoutParams params = mParams;
         mBubbleView.setOnTouchListener(new View.OnTouchListener() {
             private float downX, downY;
             private int downParamX, downParamY;
@@ -170,41 +190,188 @@ public class BubbleService extends Service {
     }
 
     private void onBubbleTap() {
-        if (isProcessing) return;
+        // Ignore taps while transcribing or reloading: keeps a rapid double
+        // tap from starting two recordings or racing the async reload.
+        if (isProcessing || isReloading) return;
         if (isRecording) {
             stopRecordingFlow();
+            return;
+        }
+        if (checkSelfPermission(android.Manifest.permission.RECORD_AUDIO)
+                != PackageManager.PERMISSION_GRANTED) {
+            Toast.makeText(this, R.string.bubble_need_mic, Toast.LENGTH_SHORT).show();
+            return;
+        }
+        if (isModelUnloaded) {
+            reloadThenRecord();
         } else {
-            if (checkSelfPermission(android.Manifest.permission.RECORD_AUDIO)
-                    != PackageManager.PERMISSION_GRANTED) {
-                Toast.makeText(this, R.string.bubble_need_mic, Toast.LENGTH_SHORT).show();
-                return;
-            }
-            isRecording = true;
-            updateBubbleState();
-            startRecordingNative();
+            beginRecording();
         }
     }
 
+    private void beginRecording() {
+        cancelIdleUnload();
+        isRecording = true;
+        updateBubbleState();
+        startRecordingNative();
+    }
+
+    /**
+     * The model was unloaded to save memory/battery. Show a loading spinner,
+     * reload asynchronously on a background thread (never blocking the UI), and
+     * only start recording once the engine reports ready. Re-validates state and
+     * permission before starting so a race can never begin a recording with no
+     * session; on failure the bubble simply returns to its idle, still-unloaded
+     * look and the overlay stays usable.
+     */
+    private void reloadThenRecord() {
+        isReloading = true;
+        isProcessing = true;
+        cancelIdleUnload();
+        updateBubbleState();
+        new Thread(() -> {
+            final boolean ok = ensureEngineNative();
+            mMainHandler.post(() -> {
+                isReloading = false;
+                if (mBubbleView == null) {
+                    isProcessing = false;
+                    return;
+                }
+                if (!ok) {
+                    isProcessing = false;
+                    isModelUnloaded = true;
+                    updateBubbleState();
+                    Toast.makeText(this, R.string.bubble_load_failed, Toast.LENGTH_SHORT).show();
+                    scheduleIdleUnload();
+                    return;
+                }
+                isModelUnloaded = false;
+                isProcessing = false;
+                if (isRecording) {
+                    updateBubbleState();
+                    return;
+                }
+                if (checkSelfPermission(android.Manifest.permission.RECORD_AUDIO)
+                        != PackageManager.PERMISSION_GRANTED) {
+                    updateBubbleState();
+                    Toast.makeText(this, R.string.bubble_need_mic, Toast.LENGTH_SHORT).show();
+                    scheduleIdleUnload();
+                    return;
+                }
+                beginRecording();
+            });
+        }).start();
+    }
+
     private void stopRecordingFlow() {
+        cancelIdleUnload();
         isRecording = false;
         isProcessing = true;
         updateBubbleState();
         stopRecordingNative();
     }
 
+    // --- Battery-aware idle unload -----------------------------------------
+
+    /**
+     * Arms a single delayed unload callback for when the bubble sits idle. Any
+     * previously armed callback is cancelled first, so there is exactly one
+     * pending callback and no polling/wakeups. "Never" (0) arms nothing.
+     */
+    private void scheduleIdleUnload() {
+        cancelIdleUnload();
+        if (mBubbleView == null) return;
+        if (isRecording || isProcessing || isReloading) return;
+        int minutes = BubblePrefs.getUnloadMinutes(this);
+        if (minutes <= 0) return;
+        mMainHandler.postDelayed(mUnloadRunnable, minutes * 60_000L);
+    }
+
+    private void cancelIdleUnload() {
+        if (mUnloadRunnable != null) mMainHandler.removeCallbacks(mUnloadRunnable);
+    }
+
+    /**
+     * Fired by the delayed callback. Drops the heavy model only if the engine
+     * is genuinely idle (no active transcription anywhere in this process —
+     * see engine::unload_if_idle). The overlay and foreground service stay
+     * visible and usable; the next tap reloads. If another engine user is
+     * busy, a single retry is re-armed instead of polling.
+     */
+    private void performIdleUnload() {
+        if (mBubbleView == null) return;
+        if (isRecording || isProcessing || isReloading) return;
+        new Thread(() -> {
+            final boolean unloaded = unloadNative();
+            mMainHandler.post(() -> {
+                if (mBubbleView == null) return;
+                if (isRecording || isProcessing || isReloading) return;
+                if (unloaded) {
+                    isModelUnloaded = true;
+                    updateBubbleState();
+                } else {
+                    scheduleIdleUnload();
+                }
+            });
+        }).start();
+    }
+
+    // --- Sizing ------------------------------------------------------------
+
+    /**
+     * Applies the persisted bubble diameter to an already-visible bubble:
+     * resizes the overlay and scales its inner icon/spinner proportionally,
+     * keeping at least a 48dp touch target, and nudges the position back on
+     * screen if the resize would push it off.
+     */
+    private void applyBubbleSize() {
+        if (mBubbleView == null || mParams == null) return;
+        int dp = BubblePrefs.getSizeDp(this);
+        float density = getResources().getDisplayMetrics().density;
+        int sizePx = Math.round(dp * density);
+        int innerPx = Math.round((dp / 2f) * density);
+
+        mParams.width = sizePx;
+        mParams.height = sizePx;
+        setViewSize(mBubbleIcon, innerPx);
+        setViewSize(mBubbleProgress, innerPx);
+
+        int maxX = Math.max(0, getResources().getDisplayMetrics().widthPixels - sizePx);
+        int maxY = Math.max(0, getResources().getDisplayMetrics().heightPixels - sizePx);
+        mParams.x = Math.min(Math.max(0, mParams.x), maxX);
+        mParams.y = Math.min(Math.max(0, mParams.y), maxY);
+
+        mWindowManager.updateViewLayout(mBubbleView, mParams);
+    }
+
+    private void setViewSize(View v, int px) {
+        if (v == null) return;
+        ViewGroup.LayoutParams lp = v.getLayoutParams();
+        lp.width = px;
+        lp.height = px;
+        v.setLayoutParams(lp);
+    }
+
     private void updateBubbleState() {
         mMainHandler.post(() -> {
-            if (mBubbleIcon == null) return;
+            if (mBubbleIcon == null || mBubbleView == null) return;
+            boolean loading = isProcessing || isReloading;
             if (isRecording) {
-                mBubbleIcon.setImageResource(R.drawable.ic_mic);
+                mBubbleIcon.setVisibility(View.VISIBLE);
+                mBubbleIcon.setImageResource(R.drawable.ic_stop);
+                if (mBubbleProgress != null) mBubbleProgress.setVisibility(View.GONE);
                 mBubbleView.setBackgroundResource(R.drawable.bg_bubble_recording);
                 mBubbleView.setContentDescription(getString(R.string.bubble_recording));
-            } else if (isProcessing) {
-                mBubbleIcon.setImageResource(R.drawable.ic_mic);
+            } else if (loading) {
+                mBubbleIcon.setVisibility(View.GONE);
+                if (mBubbleProgress != null) mBubbleProgress.setVisibility(View.VISIBLE);
                 mBubbleView.setBackgroundResource(R.drawable.bg_bubble_processing);
-                mBubbleView.setContentDescription(getString(R.string.bubble_processing));
+                mBubbleView.setContentDescription(getString(
+                        isReloading ? R.string.bubble_loading : R.string.bubble_processing));
             } else {
+                mBubbleIcon.setVisibility(View.VISIBLE);
                 mBubbleIcon.setImageResource(R.drawable.ic_mic);
+                if (mBubbleProgress != null) mBubbleProgress.setVisibility(View.GONE);
                 mBubbleView.setBackgroundResource(R.drawable.bg_bubble_idle);
                 mBubbleView.setContentDescription(getString(R.string.bubble_idle));
             }
@@ -212,10 +379,17 @@ public class BubbleService extends Service {
     }
 
     private void hideBubble() {
+        cancelIdleUnload();
+        isRecording = false;
+        isProcessing = false;
+        isReloading = false;
+        isModelUnloaded = false;
         if (mBubbleView != null && mWindowManager != null) {
             mWindowManager.removeView(mBubbleView);
             mBubbleView = null;
             mBubbleIcon = null;
+            mBubbleProgress = null;
+            mParams = null;
         }
         cleanupNative();
     }
@@ -224,9 +398,14 @@ public class BubbleService extends Service {
         mMainHandler.post(() -> {
             if (status != null && status.startsWith("Error")) {
                 isRecording = false;
+                if (isReloading) {
+                    // reloadThenRecord() owns the state reset and error toast.
+                    return;
+                }
                 isProcessing = false;
                 updateBubbleState();
                 Toast.makeText(this, status, Toast.LENGTH_SHORT).show();
+                scheduleIdleUnload();
             }
         });
     }
@@ -238,6 +417,7 @@ public class BubbleService extends Service {
         mMainHandler.post(() -> {
             isProcessing = false;
             updateBubbleState();
+            scheduleIdleUnload();
 
             if (text == null || text.trim().isEmpty()) return;
 
@@ -288,6 +468,7 @@ public class BubbleService extends Service {
 
     @Override
     public void onDestroy() {
+        cancelIdleUnload();
         hideBubble();
         super.onDestroy();
     }
@@ -301,4 +482,6 @@ public class BubbleService extends Service {
     private native void cleanupNative();
     private native void startRecordingNative();
     private native void stopRecordingNative();
+    private native boolean unloadNative();
+    private native boolean ensureEngineNative();
 }

--- a/app/src/main/java/dev/notune/transcribe/BubbleService.java
+++ b/app/src/main/java/dev/notune/transcribe/BubbleService.java
@@ -1,0 +1,304 @@
+package dev.notune.transcribe;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ServiceInfo;
+import android.graphics.PixelFormat;
+import android.os.Build;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import android.provider.Settings;
+import android.util.Log;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.WindowManager;
+import android.widget.ImageView;
+import android.widget.Toast;
+
+public class BubbleService extends Service {
+    private static final String TAG = "BubbleService";
+    public static final String ACTION_SHOW = "dev.notune.transcribe.BUBBLE_SHOW";
+    public static final String ACTION_HIDE = "dev.notune.transcribe.BUBBLE_HIDE";
+    public static final String ACTION_STOP_RECORDING = "dev.notune.transcribe.BUBBLE_STOP_REC";
+    private static final String CHANNEL_ID = "BubbleChannel";
+    private static final int NOTIFICATION_ID = 23456;
+
+    static {
+        try {
+            System.loadLibrary("c++_shared");
+            System.loadLibrary("android_transcribe_app");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native libraries", e);
+        }
+    }
+
+    private WindowManager mWindowManager;
+    private View mBubbleView;
+    private ImageView mBubbleIcon;
+    private Handler mMainHandler;
+    private boolean isRecording = false;
+    private boolean isProcessing = false;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        mMainHandler = new Handler(Looper.getMainLooper());
+        mWindowManager = (WindowManager) getSystemService(WINDOW_SERVICE);
+        createNotificationChannel();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent == null) return START_NOT_STICKY;
+        String action = intent.getAction();
+
+        if (ACTION_SHOW.equals(action)) {
+            if (!Settings.canDrawOverlays(this)) {
+                stopSelf();
+                return START_NOT_STICKY;
+            }
+            Notification notification = createNotification();
+            try {
+                if (Build.VERSION.SDK_INT >= 29) {
+                    startForeground(NOTIFICATION_ID, notification,
+                            ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE);
+                } else {
+                    startForeground(NOTIFICATION_ID, notification);
+                }
+            } catch (Exception e) {
+                Log.e(TAG, "Failed to start foreground", e);
+                stopSelf();
+                return START_NOT_STICKY;
+            }
+            showBubble();
+        } else if (ACTION_HIDE.equals(action)) {
+            hideBubble();
+            stopForeground(STOP_FOREGROUND_REMOVE);
+            stopSelf();
+        } else if (ACTION_STOP_RECORDING.equals(action)) {
+            if (isRecording) {
+                stopRecordingFlow();
+            }
+        }
+        return START_NOT_STICKY;
+    }
+
+    private void showBubble() {
+        if (mBubbleView != null) return;
+
+        mBubbleView = LayoutInflater.from(this).inflate(R.layout.bubble_overlay, null);
+        mBubbleIcon = mBubbleView.findViewById(R.id.bubble_icon);
+
+        int layoutFlag = WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
+
+        WindowManager.LayoutParams params = new WindowManager.LayoutParams(
+                WindowManager.LayoutParams.WRAP_CONTENT,
+                WindowManager.LayoutParams.WRAP_CONTENT,
+                layoutFlag,
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+                        | WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+                PixelFormat.TRANSLUCENT);
+
+        params.gravity = Gravity.TOP | Gravity.START;
+        int savedX = BubblePrefs.getX(this);
+        int savedY = BubblePrefs.getY(this);
+        if (savedX >= 0 && savedY >= 0) {
+            params.x = savedX;
+            params.y = savedY;
+        } else {
+            params.x = getResources().getDisplayMetrics().widthPixels - 160;
+            params.y = getResources().getDisplayMetrics().heightPixels / 3;
+        }
+
+        mWindowManager.addView(mBubbleView, params);
+        updateBubbleState();
+        makeDraggable(params);
+
+        initNative(this);
+    }
+
+    private void makeDraggable(WindowManager.LayoutParams params) {
+        mBubbleView.setOnTouchListener(new View.OnTouchListener() {
+            private float downX, downY;
+            private int downParamX, downParamY;
+            private boolean moved;
+
+            @Override
+            public boolean onTouch(View v, MotionEvent event) {
+                switch (event.getAction()) {
+                    case MotionEvent.ACTION_DOWN:
+                        downX = event.getRawX();
+                        downY = event.getRawY();
+                        downParamX = params.x;
+                        downParamY = params.y;
+                        moved = false;
+                        return true;
+                    case MotionEvent.ACTION_MOVE: {
+                        int dx = (int) (event.getRawX() - downX);
+                        int dy = (int) (event.getRawY() - downY);
+                        if (Math.abs(dx) > 8 || Math.abs(dy) > 8) moved = true;
+                        params.x = downParamX + dx;
+                        params.y = downParamY + dy;
+                        if (mBubbleView != null) {
+                            mWindowManager.updateViewLayout(mBubbleView, params);
+                        }
+                        return true;
+                    }
+                    case MotionEvent.ACTION_UP:
+                        if (moved) {
+                            BubblePrefs.setX(BubbleService.this, params.x);
+                            BubblePrefs.setY(BubbleService.this, params.y);
+                        } else {
+                            onBubbleTap();
+                        }
+                        return true;
+                }
+                return false;
+            }
+        });
+    }
+
+    private void onBubbleTap() {
+        if (isProcessing) return;
+        if (isRecording) {
+            stopRecordingFlow();
+        } else {
+            if (checkSelfPermission(android.Manifest.permission.RECORD_AUDIO)
+                    != PackageManager.PERMISSION_GRANTED) {
+                Toast.makeText(this, R.string.bubble_need_mic, Toast.LENGTH_SHORT).show();
+                return;
+            }
+            isRecording = true;
+            updateBubbleState();
+            startRecordingNative();
+        }
+    }
+
+    private void stopRecordingFlow() {
+        isRecording = false;
+        isProcessing = true;
+        updateBubbleState();
+        stopRecordingNative();
+    }
+
+    private void updateBubbleState() {
+        mMainHandler.post(() -> {
+            if (mBubbleIcon == null) return;
+            if (isRecording) {
+                mBubbleIcon.setImageResource(R.drawable.ic_mic);
+                mBubbleView.setBackgroundResource(R.drawable.bg_bubble_recording);
+                mBubbleView.setContentDescription(getString(R.string.bubble_recording));
+            } else if (isProcessing) {
+                mBubbleIcon.setImageResource(R.drawable.ic_mic);
+                mBubbleView.setBackgroundResource(R.drawable.bg_bubble_processing);
+                mBubbleView.setContentDescription(getString(R.string.bubble_processing));
+            } else {
+                mBubbleIcon.setImageResource(R.drawable.ic_mic);
+                mBubbleView.setBackgroundResource(R.drawable.bg_bubble_idle);
+                mBubbleView.setContentDescription(getString(R.string.bubble_idle));
+            }
+        });
+    }
+
+    private void hideBubble() {
+        if (mBubbleView != null && mWindowManager != null) {
+            mWindowManager.removeView(mBubbleView);
+            mBubbleView = null;
+            mBubbleIcon = null;
+        }
+        cleanupNative();
+    }
+
+    public void onStatusUpdate(String status) {
+        mMainHandler.post(() -> {
+            if (status != null && status.startsWith("Error")) {
+                isRecording = false;
+                isProcessing = false;
+                updateBubbleState();
+                Toast.makeText(this, status, Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    public void onAudioLevel(float level) {
+    }
+
+    public void onTextTranscribed(String text) {
+        mMainHandler.post(() -> {
+            isProcessing = false;
+            updateBubbleState();
+
+            if (text == null || text.trim().isEmpty()) return;
+
+            TranscriptionHistory.get(this).insert(text, TranscriptionHistory.SOURCE_BUBBLE);
+
+            ClipboardManager cm = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
+            cm.setPrimaryClip(ClipData.newPlainText("Transcription", text));
+
+            boolean inserted = InsertionAccessibilityService.tryInsert(this, text);
+            if (inserted) {
+                Toast.makeText(this, R.string.bubble_inserted, Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(this, R.string.bubble_copied, Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    private void createNotificationChannel() {
+        NotificationChannel channel = new NotificationChannel(
+                CHANNEL_ID, getString(R.string.bubble_channel_name),
+                NotificationManager.IMPORTANCE_LOW);
+        NotificationManager manager = getSystemService(NotificationManager.class);
+        if (manager != null) manager.createNotificationChannel(channel);
+    }
+
+    private Notification createNotification() {
+        Intent stopIntent = new Intent(this, BubbleService.class);
+        stopIntent.setAction(ACTION_HIDE);
+        PendingIntent stopPi = PendingIntent.getService(
+                this, 1, stopIntent, PendingIntent.FLAG_IMMUTABLE);
+
+        Intent stopRecIntent = new Intent(this, BubbleService.class);
+        stopRecIntent.setAction(ACTION_STOP_RECORDING);
+        PendingIntent stopRecPi = PendingIntent.getService(
+                this, 2, stopRecIntent, PendingIntent.FLAG_IMMUTABLE);
+
+        return new Notification.Builder(this, CHANNEL_ID)
+                .setContentTitle(getString(R.string.bubble_notification_title))
+                .setContentText(getString(R.string.bubble_notification_text))
+                .setSmallIcon(android.R.drawable.ic_btn_speak_now)
+                .addAction(new Notification.Action.Builder(
+                        null, getString(R.string.bubble_stop_recording), stopRecPi).build())
+                .addAction(new Notification.Action.Builder(
+                        null, getString(R.string.bubble_hide), stopPi).build())
+                .setOngoing(true)
+                .build();
+    }
+
+    @Override
+    public void onDestroy() {
+        hideBubble();
+        super.onDestroy();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    private native void initNative(BubbleService service);
+    private native void cleanupNative();
+    private native void startRecordingNative();
+    private native void stopRecordingNative();
+}

--- a/app/src/main/java/dev/notune/transcribe/CustomWordsActivity.java
+++ b/app/src/main/java/dev/notune/transcribe/CustomWordsActivity.java
@@ -1,0 +1,305 @@
+package dev.notune.transcribe;
+
+import android.os.Bundle;
+import android.text.InputType;
+import android.util.TypedValue;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.ImageButton;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.snackbar.Snackbar;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Edits the custom-word list that biases Whisper recognition (see
+ * {@link CustomWordsPrefs}). Supports single add/edit/remove and a one-per-line
+ * bulk import. Every change reloads the shared engine through the same native
+ * path the Models screen uses, so the new initial prompt applies to all
+ * transcription entry points (keyboard, bubble, subtitles, shared files).
+ */
+public class CustomWordsActivity extends AppCompatActivity {
+
+    static {
+        try {
+            System.loadLibrary("c++_shared");
+        } catch (UnsatisfiedLinkError ignored) { }
+        System.loadLibrary("android_transcribe_app");
+    }
+
+    private RecyclerView recyclerView;
+    private WordsAdapter adapter;
+    private View emptyView;
+    private TextView statusText;
+    private TextView countText;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_custom_words);
+
+        setSupportActionBar(findViewById(R.id.toolbar));
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+
+        statusText = findViewById(R.id.txt_custom_words_status);
+        countText = findViewById(R.id.txt_custom_words_count);
+        recyclerView = findViewById(R.id.custom_words_list);
+        emptyView = findViewById(R.id.custom_words_empty);
+
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        adapter = new WordsAdapter();
+        recyclerView.setAdapter(adapter);
+
+        findViewById(R.id.btn_custom_words_add).setOnClickListener(v -> showAddDialog());
+        findViewById(R.id.btn_custom_words_import).setOnClickListener(v -> showImportDialog());
+        findViewById(R.id.btn_custom_words_help).setOnClickListener(v -> showHelpDialog());
+
+        refreshStatus();
+        loadWords();
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
+    }
+
+    // --- Active model status ------------------------------------------------
+
+    /** Name of the selected model, for the status line. */
+    private String activeModelName() {
+        String active = readConfig("active_model");
+        return active.isEmpty() ? getString(R.string.custom_words_builtin) : active;
+    }
+
+    /**
+     * Best-effort check for whether the active model is a Whisper model, which
+     * is the only family that uses custom words. The built-in model is Parakeet
+     * (not Whisper); imported GGUFs are judged by their file name.
+     */
+    private boolean activeModelIsWhisper() {
+        String active = readConfig("active_model");
+        return !active.isEmpty() && active.toLowerCase(Locale.ROOT).contains("whisper");
+    }
+
+    private void refreshStatus() {
+        String status = getString(R.string.custom_words_active_model, activeModelName());
+        if (!activeModelIsWhisper()) {
+            status += "\n" + getString(R.string.custom_words_not_whisper);
+        }
+        statusText.setText(status);
+    }
+
+    // --- List ---------------------------------------------------------------
+
+    private void loadWords() {
+        List<String> words = CustomWordsPrefs.getAll(this);
+        adapter.setWords(words);
+        boolean empty = words.isEmpty();
+        emptyView.setVisibility(empty ? View.VISIBLE : View.GONE);
+        recyclerView.setVisibility(empty ? View.GONE : View.VISIBLE);
+        countText.setText(getResources().getQuantityString(
+                R.plurals.custom_words_count, words.size(), words.size()));
+    }
+
+    /** Persists a change made through the UI and reloads the shared engine. */
+    private void applyAndReload() {
+        loadWords();
+        reloadModelNative(this);
+    }
+
+    // --- Add / edit / remove ------------------------------------------------
+
+    private void showAddDialog() {
+        EditText input = newSingleLineInput();
+        new MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.custom_words_add)
+                .setView(wrapInput(input))
+                .setPositiveButton(android.R.string.ok, (d, w) -> {
+                    CustomWordsPrefs.AddResult r = CustomWordsPrefs.add(this, input.getText().toString());
+                    reportAdd(r, input.getText().toString());
+                    if (r == CustomWordsPrefs.AddResult.ADDED) applyAndReload();
+                })
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
+    }
+
+    private void showEditDialog(String current) {
+        EditText input = newSingleLineInput();
+        input.setText(current);
+        input.setSelection(current.length());
+        new MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.custom_words_edit)
+                .setView(wrapInput(input))
+                .setPositiveButton(android.R.string.ok, (d, w) -> {
+                    CustomWordsPrefs.AddResult r =
+                            CustomWordsPrefs.update(this, current, input.getText().toString());
+                    reportAdd(r, input.getText().toString());
+                    if (r == CustomWordsPrefs.AddResult.ADDED) applyAndReload();
+                })
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
+    }
+
+    private void showImportDialog() {
+        EditText input = new EditText(this);
+        input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE);
+        input.setMinLines(5);
+        input.setGravity(android.view.Gravity.TOP);
+        input.setHint(R.string.custom_words_import_hint);
+        new MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.custom_words_import)
+                .setView(wrapInput(input))
+                .setPositiveButton(android.R.string.ok, (d, w) -> {
+                    int added = CustomWordsPrefs.importBulk(this, input.getText().toString());
+                    if (added > 0) {
+                        snackbar(getString(R.string.custom_words_import_done, added));
+                        applyAndReload();
+                    } else {
+                        snackbar(getString(R.string.custom_words_import_none));
+                    }
+                })
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
+    }
+
+    /** Maps an add/edit outcome to user feedback. */
+    private void reportAdd(CustomWordsPrefs.AddResult r, String raw) {
+        switch (r) {
+            case ADDED:
+                snackbar(getString(R.string.custom_words_saved));
+                break;
+            case EMPTY:
+                snackbar(getString(R.string.custom_words_empty_input));
+                break;
+            case TOO_LONG:
+                snackbar(getString(R.string.custom_words_too_long,
+                        CustomWordsPrefs.MAX_ENTRY_LENGTH));
+                break;
+            case DUPLICATE:
+                snackbar(getString(R.string.custom_words_duplicate));
+                break;
+            case LIMIT_REACHED:
+                snackbar(getString(R.string.custom_words_limit, CustomWordsPrefs.MAX_WORDS));
+                break;
+        }
+    }
+
+    // --- Privacy / help -----------------------------------------------------
+
+    private void showHelpDialog() {
+        new MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.custom_words_help_title)
+                .setMessage(R.string.custom_words_help_body)
+                .setPositiveButton(android.R.string.ok, null)
+                .show();
+    }
+
+    // --- Helpers ------------------------------------------------------------
+
+    private EditText newSingleLineInput() {
+        EditText input = new EditText(this);
+        input.setInputType(InputType.TYPE_CLASS_TEXT);
+        input.setSingleLine(true);
+        input.setHint(R.string.custom_words_add_hint);
+        return input;
+    }
+
+    /** Wraps an EditText in padding so dialog content isn't flush to the edge. */
+    private View wrapInput(View input) {
+        FrameLayout container = new FrameLayout(this);
+        int pad = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 20,
+                getResources().getDisplayMetrics());
+        FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        lp.setMargins(pad, pad / 2, pad, 0);
+        container.addView(input, lp);
+        container.setPadding(0, 0, 0, pad / 2);
+        return container;
+    }
+
+    private String readConfig(String name) {
+        File f = new File(getFilesDir(), name);
+        if (!f.exists()) return "";
+        try {
+            return new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8).trim();
+        } catch (IOException e) {
+            return "";
+        }
+    }
+
+    private void snackbar(String message) {
+        Snackbar.make(findViewById(android.R.id.content), message, Snackbar.LENGTH_LONG).show();
+    }
+
+    // Called from Rust with reload progress ("Loading model...", "Ready", ...).
+    public void onStatusUpdate(String status) {
+        runOnUiThread(() -> statusText.setText(status));
+    }
+
+    private native void reloadModelNative(CustomWordsActivity activity);
+
+    // --- Adapter ------------------------------------------------------------
+
+    private class WordsAdapter extends RecyclerView.Adapter<WordsAdapter.VH> {
+        private final List<String> words = new ArrayList<>();
+
+        void setWords(List<String> list) {
+            words.clear();
+            words.addAll(list);
+            notifyDataSetChanged();
+        }
+
+        @Override
+        public VH onCreateViewHolder(ViewGroup parent, int viewType) {
+            View v = LayoutInflater.from(parent.getContext())
+                    .inflate(R.layout.item_custom_word, parent, false);
+            return new VH(v);
+        }
+
+        @Override
+        public void onBindViewHolder(VH h, int position) {
+            String word = words.get(position);
+            h.text.setText(word);
+            h.editBtn.setOnClickListener(v -> showEditDialog(word));
+            h.deleteBtn.setOnClickListener(v -> {
+                CustomWordsPrefs.remove(CustomWordsActivity.this, word);
+                applyAndReload();
+            });
+        }
+
+        @Override
+        public int getItemCount() {
+            return words.size();
+        }
+
+        class VH extends RecyclerView.ViewHolder {
+            TextView text;
+            ImageButton editBtn, deleteBtn;
+
+            VH(View v) {
+                super(v);
+                text = v.findViewById(R.id.custom_word_text);
+                editBtn = v.findViewById(R.id.custom_word_edit);
+                deleteBtn = v.findViewById(R.id.custom_word_delete);
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/notune/transcribe/CustomWordsPrefs.java
+++ b/app/src/main/java/dev/notune/transcribe/CustomWordsPrefs.java
@@ -1,0 +1,148 @@
+package dev.notune.transcribe;
+
+import android.content.Context;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Persists the user's custom-word list as a plain-text file in filesDir, one
+ * entry per line — the same marker-file pattern the Rust engine reads for every
+ * other setting ({@code custom_words}). Whisper models receive the list as their
+ * initial prompt, a recognition bias toward these words; models without Whisper
+ * support ignore it.
+ *
+ * This class is the single authority for normalization. Entries are trimmed,
+ * inner whitespace is collapsed to a single space, and the list is
+ * case-insensitively de-duplicated with first spelling and first position
+ * winning. Explicit caps ({@link #MAX_WORDS}, {@link #MAX_ENTRY_LENGTH}) keep a
+ * large paste from bloating the prompt the model is handed on every run.
+ */
+public final class CustomWordsPrefs {
+    private static final String FILE_NAME = "custom_words";
+    /** Hard cap on list size, so the per-run prompt stays bounded. */
+    public static final int MAX_WORDS = 200;
+    /** Hard cap on a single entry's length after normalization. */
+    public static final int MAX_ENTRY_LENGTH = 60;
+
+    private CustomWordsPrefs() {}
+
+    /** Outcome of an add/edit attempt, so the UI can give specific feedback. */
+    public enum AddResult { ADDED, EMPTY, TOO_LONG, DUPLICATE, LIMIT_REACHED }
+
+    /**
+     * Normalizes one raw entry: trims it and collapses inner whitespace runs to
+     * a single space. Returns null when nothing usable remains. Length is not
+     * checked here so callers can report "too long" distinctly from "empty".
+     */
+    public static String normalize(String raw) {
+        if (raw == null) return null;
+        String s = raw.trim().replaceAll("\\s+", " ");
+        return s.isEmpty() ? null : s;
+    }
+
+    /** The stored list, in order. Empty if the file is absent or unreadable. */
+    public static List<String> getAll(Context ctx) {
+        List<String> list = new ArrayList<>();
+        File f = new File(ctx.getFilesDir(), FILE_NAME);
+        if (!f.exists()) return list;
+        try {
+            String content = new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8);
+            for (String line : content.split("\n")) {
+                String s = line.trim();
+                if (!s.isEmpty()) list.add(s);
+            }
+        } catch (IOException ignored) { }
+        return list;
+    }
+
+    /** Writes the list verbatim (callers pass an already-normalized list). */
+    private static void saveAll(Context ctx, List<String> words) {
+        File f = new File(ctx.getFilesDir(), FILE_NAME);
+        if (words.isEmpty()) {
+            f.delete();
+            return;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (String w : words) sb.append(w).append('\n');
+        try {
+            Files.write(f.toPath(), sb.toString().getBytes(StandardCharsets.UTF_8));
+        } catch (IOException ignored) { }
+    }
+
+    /** Adds one entry. De-duplicates case-insensitively; respects the caps. */
+    public static AddResult add(Context ctx, String raw) {
+        String word = normalize(raw);
+        if (word == null) return AddResult.EMPTY;
+        if (word.length() > MAX_ENTRY_LENGTH) return AddResult.TOO_LONG;
+        List<String> list = getAll(ctx);
+        if (containsIgnoreCase(list, word)) return AddResult.DUPLICATE;
+        if (list.size() >= MAX_WORDS) return AddResult.LIMIT_REACHED;
+        list.add(word);
+        saveAll(ctx, list);
+        return AddResult.ADDED;
+    }
+
+    /** Removes an entry matched case-insensitively. No-op if not present. */
+    public static void remove(Context ctx, String word) {
+        List<String> list = getAll(ctx);
+        if (list.removeIf(w -> w.equalsIgnoreCase(word))) {
+            saveAll(ctx, list);
+        }
+    }
+
+    /**
+     * Replaces {@code oldWord} (matched case-insensitively) with a normalized
+     * {@code newRaw}, keeping its position. Editing to a value already present
+     * elsewhere reports {@link AddResult#DUPLICATE}; editing only the casing of
+     * an entry is allowed.
+     */
+    public static AddResult update(Context ctx, String oldWord, String newRaw) {
+        String word = normalize(newRaw);
+        if (word == null) return AddResult.EMPTY;
+        if (word.length() > MAX_ENTRY_LENGTH) return AddResult.TOO_LONG;
+        List<String> list = getAll(ctx);
+        int idx = indexOfIgnoreCase(list, oldWord);
+        if (idx < 0) return AddResult.EMPTY;
+        int existing = indexOfIgnoreCase(list, word);
+        if (existing >= 0 && existing != idx) return AddResult.DUPLICATE;
+        list.set(idx, word);
+        saveAll(ctx, list);
+        return AddResult.ADDED;
+    }
+
+    /**
+     * Imports one entry per line. Returns how many were actually added; blanks,
+     * over-long, duplicate and over-limit entries are skipped.
+     */
+    public static int importBulk(Context ctx, String text) {
+        if (text == null) return 0;
+        List<String> list = getAll(ctx);
+        int added = 0;
+        for (String line : text.split("\n")) {
+            String word = normalize(line);
+            if (word == null || word.length() > MAX_ENTRY_LENGTH) continue;
+            if (containsIgnoreCase(list, word)) continue;
+            if (list.size() >= MAX_WORDS) break;
+            list.add(word);
+            added++;
+        }
+        if (added > 0) saveAll(ctx, list);
+        return added;
+    }
+
+    private static boolean containsIgnoreCase(List<String> list, String word) {
+        return indexOfIgnoreCase(list, word) >= 0;
+    }
+
+    private static int indexOfIgnoreCase(List<String> list, String word) {
+        for (int i = 0; i < list.size(); i++) {
+            if (list.get(i).equalsIgnoreCase(word)) return i;
+        }
+        return -1;
+    }
+}

--- a/app/src/main/java/dev/notune/transcribe/HistoryActivity.java
+++ b/app/src/main/java/dev/notune/transcribe/HistoryActivity.java
@@ -1,0 +1,156 @@
+package dev.notune.transcribe;
+
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageButton;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import java.text.DateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class HistoryActivity extends AppCompatActivity {
+
+    private RecyclerView recyclerView;
+    private HistoryAdapter adapter;
+    private View emptyView;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_history);
+
+        setSupportActionBar(findViewById(R.id.toolbar));
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+
+        recyclerView = findViewById(R.id.history_list);
+        emptyView = findViewById(R.id.history_empty);
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        adapter = new HistoryAdapter();
+        recyclerView.setAdapter(adapter);
+
+        findViewById(R.id.btn_clear_all).setOnClickListener(v -> confirmClearAll());
+
+        loadHistory();
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
+    }
+
+    private void loadHistory() {
+        List<TranscriptionHistory.Entry> entries =
+                TranscriptionHistory.get(this).query(0);
+        adapter.setEntries(entries);
+        emptyView.setVisibility(entries.isEmpty() ? View.VISIBLE : View.GONE);
+        recyclerView.setVisibility(entries.isEmpty() ? View.GONE : View.VISIBLE);
+    }
+
+    private void confirmClearAll() {
+        new MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.history_clear_title)
+                .setMessage(R.string.history_clear_body)
+                .setPositiveButton(R.string.history_clear_confirm, (d, w) -> {
+                    TranscriptionHistory.get(this).clearAll();
+                    loadHistory();
+                })
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
+    }
+
+    private class HistoryAdapter extends RecyclerView.Adapter<HistoryAdapter.VH> {
+        private final List<TranscriptionHistory.Entry> entries = new ArrayList<>();
+        private final DateFormat fmt = DateFormat.getDateTimeInstance(
+                DateFormat.SHORT, DateFormat.SHORT);
+
+        void setEntries(List<TranscriptionHistory.Entry> list) {
+            entries.clear();
+            entries.addAll(list);
+            notifyDataSetChanged();
+        }
+
+        @Override
+        public VH onCreateViewHolder(ViewGroup parent, int viewType) {
+            View v = LayoutInflater.from(parent.getContext())
+                    .inflate(R.layout.item_history, parent, false);
+            return new VH(v);
+        }
+
+        @Override
+        public void onBindViewHolder(VH h, int position) {
+            TranscriptionHistory.Entry e = entries.get(position);
+            h.text.setText(e.text);
+            h.meta.setText(getString(R.string.history_meta,
+                    sourceLabel(e.source), fmt.format(new Date(e.timestamp))));
+
+            h.copyBtn.setOnClickListener(v -> {
+                ClipboardManager cm = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
+                cm.setPrimaryClip(ClipData.newPlainText("Transcription", e.text));
+                Toast.makeText(HistoryActivity.this,
+                        R.string.history_copied, Toast.LENGTH_SHORT).show();
+            });
+
+            h.deleteBtn.setOnClickListener(v -> {
+                TranscriptionHistory.get(HistoryActivity.this).delete(e.id);
+                entries.remove(position);
+                notifyItemRemoved(position);
+                notifyItemRangeChanged(position, entries.size());
+                if (entries.isEmpty()) {
+                    emptyView.setVisibility(View.VISIBLE);
+                    recyclerView.setVisibility(View.GONE);
+                }
+            });
+        }
+
+        @Override
+        public int getItemCount() {
+            return entries.size();
+        }
+
+        private String sourceLabel(String source) {
+            switch (source) {
+                case TranscriptionHistory.SOURCE_BUBBLE:
+                    return getString(R.string.history_source_bubble);
+                case TranscriptionHistory.SOURCE_POPUP:
+                    return getString(R.string.history_source_popup);
+                case TranscriptionHistory.SOURCE_IME:
+                    return getString(R.string.history_source_ime);
+                case TranscriptionHistory.SOURCE_FILE:
+                    return getString(R.string.history_source_file);
+                case TranscriptionHistory.SOURCE_SERVICE:
+                    return getString(R.string.history_source_service);
+                default:
+                    return source;
+            }
+        }
+
+        class VH extends RecyclerView.ViewHolder {
+            TextView text, meta;
+            ImageButton copyBtn, deleteBtn;
+
+            VH(View v) {
+                super(v);
+                text = v.findViewById(R.id.history_item_text);
+                meta = v.findViewById(R.id.history_item_meta);
+                copyBtn = v.findViewById(R.id.history_item_copy);
+                deleteBtn = v.findViewById(R.id.history_item_delete);
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/notune/transcribe/HistoryPrefs.java
+++ b/app/src/main/java/dev/notune/transcribe/HistoryPrefs.java
@@ -1,0 +1,33 @@
+package dev.notune.transcribe;
+
+import android.content.Context;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+public final class HistoryPrefs {
+    private static final String FILE_NAME = "history_retention";
+    public static final int DEFAULT_RETENTION = 25;
+
+    private HistoryPrefs() {}
+
+    public static int getRetention(Context ctx) {
+        File f = new File(ctx.getFilesDir(), FILE_NAME);
+        if (!f.exists()) return DEFAULT_RETENTION;
+        try {
+            String s = new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8).trim();
+            return Integer.parseInt(s);
+        } catch (IOException | NumberFormatException e) {
+            return DEFAULT_RETENTION;
+        }
+    }
+
+    public static void setRetention(Context ctx, int count) {
+        File f = new File(ctx.getFilesDir(), FILE_NAME);
+        try {
+            Files.write(f.toPath(), String.valueOf(count).getBytes(StandardCharsets.UTF_8));
+        } catch (IOException ignored) { }
+    }
+}

--- a/app/src/main/java/dev/notune/transcribe/InsertionAccessibilityService.java
+++ b/app/src/main/java/dev/notune/transcribe/InsertionAccessibilityService.java
@@ -1,0 +1,105 @@
+package dev.notune.transcribe;
+
+import android.accessibilityservice.AccessibilityService;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
+
+public class InsertionAccessibilityService extends AccessibilityService {
+    private static final String TAG = "InsertionA11y";
+
+    private static volatile InsertionAccessibilityService sInstance;
+
+    @Override
+    public void onServiceConnected() {
+        super.onServiceConnected();
+        sInstance = this;
+    }
+
+    @Override
+    public void onAccessibilityEvent(AccessibilityEvent event) {
+    }
+
+    @Override
+    public void onInterrupt() {
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (sInstance == this) sInstance = null;
+    }
+
+    public static boolean tryInsert(Context ctx, String text) {
+        if (!BubblePrefs.hasA11yConsent(ctx)) return false;
+        InsertionAccessibilityService svc = sInstance;
+        if (svc == null) return false;
+
+        try {
+            AccessibilityNodeInfo root = svc.getRootInActiveWindow();
+            if (root == null) return false;
+
+            AccessibilityNodeInfo focused = root.findFocus(
+                    AccessibilityNodeInfo.FOCUS_INPUT);
+            if (focused == null) {
+                root.recycle();
+                return false;
+            }
+
+            if (!isSafeEditable(focused)) {
+                focused.recycle();
+                root.recycle();
+                return false;
+            }
+
+            // BubbleService places the transcription on the clipboard first.
+            // ACTION_PASTE inserts at the app-managed cursor without reading,
+            // retaining, or reconstructing any existing field content.
+            boolean ok = focused.performAction(AccessibilityNodeInfo.ACTION_PASTE);
+
+            focused.recycle();
+            root.recycle();
+            return ok;
+        } catch (Exception e) {
+            Log.w(TAG, "Insertion failed", e);
+            return false;
+        }
+    }
+
+    private static boolean isSafeEditable(AccessibilityNodeInfo node) {
+        if (!node.isEditable()) return false;
+        if (!node.isVisibleToUser()) return false;
+
+        CharSequence cls = node.getClassName();
+        if (cls != null) {
+            String s = cls.toString();
+            if (s.contains("password") || s.contains("Password")) return false;
+        }
+
+        if (node.isPassword()) return false;
+
+        int inputType = 0;
+        try {
+            Bundle extras = node.getExtras();
+            if (extras != null) {
+                inputType = extras.getInt("android.view.inputmethod.EditorInfo.inputType", 0);
+            }
+        } catch (Exception ignored) {
+        }
+        int variation = inputType & 0x000000f0;
+        if (variation == 0x00000080) return false; // TYPE_TEXT_VARIATION_PASSWORD
+        if (variation == 0x00000010) return false; // TYPE_NUMBER_VARIATION_PASSWORD
+        if (variation == 0x00000090) return false; // TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
+        if (variation == 0x000000e0) return false; // TYPE_TEXT_VARIATION_WEB_PASSWORD
+
+        return true;
+    }
+
+    public static void openSettings(Context ctx) {
+        ctx.startActivity(new Intent(android.provider.Settings.ACTION_ACCESSIBILITY_SETTINGS)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
+    }
+}

--- a/app/src/main/java/dev/notune/transcribe/MainActivity.java
+++ b/app/src/main/java/dev/notune/transcribe/MainActivity.java
@@ -95,6 +95,8 @@ public class MainActivity extends AppCompatActivity {
         setupBubbleSwitch();
         setupA11ySwitch();
         setupRetentionRadio();
+        setupBubbleUnloadRadio();
+        setupBubbleSizeRadio();
 
         benchButton = findViewById(R.id.btn_benchmark);
         benchResultText = findViewById(R.id.text_bench_result);
@@ -386,6 +388,50 @@ public class MainActivity extends AppCompatActivity {
             HistoryPrefs.setRetention(this, val);
             TranscriptionHistory.get(this).prune();
         });
+    }
+
+    private void setupBubbleUnloadRadio() {
+        RadioGroup rg = findViewById(R.id.rg_bubble_unload);
+        switch (BubblePrefs.getUnloadMinutes(this)) {
+            case 0: rg.check(R.id.rb_unload_never); break;
+            case 5: rg.check(R.id.rb_unload_5); break;
+            case 30: rg.check(R.id.rb_unload_30); break;
+            default: rg.check(R.id.rb_unload_15); break;
+        }
+        rg.setOnCheckedChangeListener((group, checkedId) -> {
+            int val;
+            if (checkedId == R.id.rb_unload_never) val = 0;
+            else if (checkedId == R.id.rb_unload_5) val = 5;
+            else if (checkedId == R.id.rb_unload_30) val = 30;
+            else val = 15;
+            BubblePrefs.setUnloadMinutes(this, val);
+            notifyBubbleRefresh();
+        });
+    }
+
+    private void setupBubbleSizeRadio() {
+        RadioGroup rg = findViewById(R.id.rg_bubble_size);
+        switch (BubblePrefs.getSizeDp(this)) {
+            case 48: rg.check(R.id.rb_size_small); break;
+            case 72: rg.check(R.id.rb_size_large); break;
+            default: rg.check(R.id.rb_size_medium); break;
+        }
+        rg.setOnCheckedChangeListener((group, checkedId) -> {
+            int val;
+            if (checkedId == R.id.rb_size_small) val = 48;
+            else if (checkedId == R.id.rb_size_large) val = 72;
+            else val = 56;
+            BubblePrefs.setSizeDp(this, val);
+            notifyBubbleRefresh();
+        });
+    }
+
+    /** Tells a visible bubble to re-read its settings (size / unload interval). */
+    private void notifyBubbleRefresh() {
+        if (!BubblePrefs.isEnabled(this)) return;
+        Intent intent = new Intent(this, BubbleService.class);
+        intent.setAction(BubbleService.ACTION_REFRESH);
+        startService(intent);
     }
 
     @Override

--- a/app/src/main/java/dev/notune/transcribe/MainActivity.java
+++ b/app/src/main/java/dev/notune/transcribe/MainActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.content.res.ColorStateList;
+import android.net.Uri;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.speech.RecognizerIntent;
@@ -15,6 +16,7 @@ import android.widget.CompoundButton;
 import android.widget.ImageView;
 import android.widget.RadioGroup;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
@@ -83,6 +85,16 @@ public class MainActivity extends AppCompatActivity {
 
         findViewById(R.id.btn_models).setOnClickListener(v ->
                 startActivity(new Intent(this, ModelsActivity.class)));
+
+        findViewById(R.id.btn_custom_words).setOnClickListener(v ->
+                startActivity(new Intent(this, CustomWordsActivity.class)));
+
+        findViewById(R.id.btn_history).setOnClickListener(v ->
+                startActivity(new Intent(this, HistoryActivity.class)));
+
+        setupBubbleSwitch();
+        setupA11ySwitch();
+        setupRetentionRadio();
 
         benchButton = findViewById(R.id.btn_benchmark);
         benchResultText = findViewById(R.id.text_bench_result);
@@ -304,6 +316,76 @@ public class MainActivity extends AppCompatActivity {
         if (checkSelfPermission(android.Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
             requestPermissions(new String[]{android.Manifest.permission.RECORD_AUDIO}, PERM_REQ_CODE);
         }
+    }
+
+    private void setupBubbleSwitch() {
+        CompoundButton sw = findViewById(R.id.switch_bubble);
+        sw.setChecked(BubblePrefs.isEnabled(this));
+        sw.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            if (isChecked) {
+                if (!Settings.canDrawOverlays(this)) {
+                    sw.setChecked(false);
+                    Toast.makeText(this, R.string.bubble_need_overlay, Toast.LENGTH_LONG).show();
+                    startActivity(new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                            Uri.parse("package:" + getPackageName())));
+                    return;
+                }
+                BubblePrefs.setEnabled(this, true);
+                Intent intent = new Intent(this, BubbleService.class);
+                intent.setAction(BubbleService.ACTION_SHOW);
+                ContextCompat.startForegroundService(this, intent);
+            } else {
+                BubblePrefs.setEnabled(this, false);
+                Intent intent = new Intent(this, BubbleService.class);
+                intent.setAction(BubbleService.ACTION_HIDE);
+                startService(intent);
+            }
+        });
+    }
+
+    private void setupA11ySwitch() {
+        CompoundButton sw = findViewById(R.id.switch_a11y);
+        sw.setChecked(BubblePrefs.hasA11yConsent(this));
+        sw.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            if (isChecked) {
+                new MaterialAlertDialogBuilder(this)
+                        .setTitle(R.string.a11y_consent_title)
+                        .setMessage(R.string.a11y_consent_body)
+                        .setPositiveButton(R.string.a11y_consent_accept, (d, w) -> {
+                            BubblePrefs.setA11yConsent(this, true);
+                            InsertionAccessibilityService.openSettings(this);
+                        })
+                        .setNegativeButton(android.R.string.cancel, (d, w) -> sw.setChecked(false))
+                        .setOnCancelListener(d -> sw.setChecked(false))
+                        .show();
+            } else {
+                BubblePrefs.setA11yConsent(this, false);
+            }
+        });
+    }
+
+    private void setupRetentionRadio() {
+        RadioGroup rg = findViewById(R.id.rg_retention);
+        int retention = HistoryPrefs.getRetention(this);
+        switch (retention) {
+            case 0: rg.check(R.id.rb_ret_off); break;
+            case 10: rg.check(R.id.rb_ret_10); break;
+            case 25: rg.check(R.id.rb_ret_25); break;
+            case 50: rg.check(R.id.rb_ret_50); break;
+            case 100: rg.check(R.id.rb_ret_100); break;
+            default: rg.check(R.id.rb_ret_unlimited); break;
+        }
+        rg.setOnCheckedChangeListener((group, checkedId) -> {
+            int val;
+            if (checkedId == R.id.rb_ret_off) val = 0;
+            else if (checkedId == R.id.rb_ret_10) val = 10;
+            else if (checkedId == R.id.rb_ret_25) val = 25;
+            else if (checkedId == R.id.rb_ret_50) val = 50;
+            else if (checkedId == R.id.rb_ret_100) val = 100;
+            else val = -1;
+            HistoryPrefs.setRetention(this, val);
+            TranscriptionHistory.get(this).prune();
+        });
     }
 
     @Override

--- a/app/src/main/java/dev/notune/transcribe/RecognizeActivity.java
+++ b/app/src/main/java/dev/notune/transcribe/RecognizeActivity.java
@@ -158,6 +158,8 @@ public class RecognizeActivity extends AppCompatActivity {
                 return;
             }
 
+            TranscriptionHistory.get(this).insert(text, TranscriptionHistory.SOURCE_POPUP);
+
             ArrayList<String> results = new ArrayList<>();
             results.add(text);
 

--- a/app/src/main/java/dev/notune/transcribe/RustInputMethodService.java
+++ b/app/src/main/java/dev/notune/transcribe/RustInputMethodService.java
@@ -470,15 +470,14 @@ public class RustInputMethodService extends InputMethodService {
                 }
                 return;
             }
+
+            TranscriptionHistory.get(this).insert(text, TranscriptionHistory.SOURCE_IME);
+
             String committed = text + " ";
             InputConnection ic = getCurrentInputConnection();
             if (inputActive && ic != null) {
                 commitTranscribedText(ic, committed);
             } else {
-                // No editor is focused right now (common on long transcribes where
-                // a web field in Firefox/Gemini dropped focus while we processed
-                // audio). Committing now would be silently dropped, so defer the
-                // text until a field is focused again instead of losing it.
                 pendingCommitText = committed;
             }
             if (pauseAudioActive) {

--- a/app/src/main/java/dev/notune/transcribe/TranscribeFileActivity.java
+++ b/app/src/main/java/dev/notune/transcribe/TranscribeFileActivity.java
@@ -126,6 +126,8 @@ public class TranscribeFileActivity extends AppCompatActivity {
 
             resultText.setText(text);
 
+            TranscriptionHistory.get(this).insert(text, TranscriptionHistory.SOURCE_FILE);
+
             // Auto-copy to clipboard
             ClipboardManager clipboard = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
             ClipData clip = ClipData.newPlainText("Transcription", text);

--- a/app/src/main/java/dev/notune/transcribe/TranscriptionHistory.java
+++ b/app/src/main/java/dev/notune/transcribe/TranscriptionHistory.java
@@ -1,0 +1,128 @@
+package dev.notune.transcribe;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class TranscriptionHistory extends SQLiteOpenHelper {
+
+    private static final String DB_NAME = "transcription_history.db";
+    private static final int DB_VERSION = 1;
+
+    public static final String TABLE = "history";
+    public static final String COL_ID = "_id";
+    public static final String COL_TEXT = "text";
+    public static final String COL_SOURCE = "source";
+    public static final String COL_TIMESTAMP = "timestamp";
+
+    public static final String SOURCE_BUBBLE = "bubble";
+    public static final String SOURCE_POPUP = "popup";
+    public static final String SOURCE_IME = "ime";
+    public static final String SOURCE_FILE = "file";
+    public static final String SOURCE_SERVICE = "service";
+
+    private static volatile TranscriptionHistory sInstance;
+    private final Context appCtx;
+
+    public static TranscriptionHistory get(Context ctx) {
+        if (sInstance == null) {
+            synchronized (TranscriptionHistory.class) {
+                if (sInstance == null) {
+                    sInstance = new TranscriptionHistory(ctx.getApplicationContext());
+                }
+            }
+        }
+        return sInstance;
+    }
+
+    private TranscriptionHistory(Context ctx) {
+        super(ctx, DB_NAME, null, DB_VERSION);
+        appCtx = ctx;
+    }
+
+    static void resetForTesting() {
+        sInstance = null;
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        db.execSQL("CREATE TABLE " + TABLE + " ("
+                + COL_ID + " INTEGER PRIMARY KEY AUTOINCREMENT, "
+                + COL_TEXT + " TEXT NOT NULL, "
+                + COL_SOURCE + " TEXT NOT NULL, "
+                + COL_TIMESTAMP + " INTEGER NOT NULL)");
+        db.execSQL("CREATE INDEX idx_ts ON " + TABLE + " (" + COL_TIMESTAMP + " DESC)");
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+    }
+
+    public void insert(String text, String source) {
+        if (text == null || text.trim().isEmpty()) return;
+        int retention = HistoryPrefs.getRetention(appCtx);
+        if (retention == 0) return;
+        ContentValues cv = new ContentValues(3);
+        cv.put(COL_TEXT, text.trim());
+        cv.put(COL_SOURCE, source);
+        cv.put(COL_TIMESTAMP, System.currentTimeMillis());
+        getWritableDatabase().insert(TABLE, null, cv);
+        if (retention > 0) prune(retention);
+    }
+
+    public List<Entry> query(int limit) {
+        List<Entry> list = new ArrayList<>();
+        String lim = limit > 0 ? String.valueOf(limit) : null;
+        try (Cursor c = getReadableDatabase().query(TABLE,
+                new String[]{COL_ID, COL_TEXT, COL_SOURCE, COL_TIMESTAMP},
+                null, null, null, null,
+                COL_TIMESTAMP + " DESC, " + COL_ID + " DESC", lim)) {
+            while (c.moveToNext()) {
+                list.add(new Entry(
+                        c.getLong(0), c.getString(1), c.getString(2), c.getLong(3)));
+            }
+        }
+        return list;
+    }
+
+    public void delete(long id) {
+        getWritableDatabase().delete(TABLE, COL_ID + "=?", new String[]{String.valueOf(id)});
+    }
+
+    public void clearAll() {
+        getWritableDatabase().delete(TABLE, null, null);
+    }
+
+    public void prune() {
+        int retention = HistoryPrefs.getRetention(appCtx);
+        if (retention <= 0) return;
+        prune(retention);
+    }
+
+    private void prune(int retention) {
+        SQLiteDatabase db = getWritableDatabase();
+        db.execSQL("DELETE FROM " + TABLE + " WHERE " + COL_ID + " NOT IN ("
+                + "SELECT " + COL_ID + " FROM " + TABLE
+                + " ORDER BY " + COL_TIMESTAMP + " DESC, " + COL_ID + " DESC LIMIT "
+                + retention + ")");
+    }
+
+    public static final class Entry {
+        public final long id;
+        public final String text;
+        public final String source;
+        public final long timestamp;
+
+        Entry(long id, String text, String source, long timestamp) {
+            this.id = id;
+            this.text = text;
+            this.source = source;
+            this.timestamp = timestamp;
+        }
+    }
+}

--- a/app/src/main/java/dev/notune/transcribe/VoiceRecognitionService.java
+++ b/app/src/main/java/dev/notune/transcribe/VoiceRecognitionService.java
@@ -138,6 +138,7 @@ public class VoiceRecognitionService extends RecognitionService {
         mainHandler.post(() -> {
             Callback cb = mCallback;
             if (cb == null) return;
+            TranscriptionHistory.get(this).insert(text, TranscriptionHistory.SOURCE_SERVICE);
             ArrayList<String> hypotheses = new ArrayList<>();
             hypotheses.add(text);
             Bundle bundle = new Bundle();

--- a/app/src/main/res/drawable/bg_bubble_idle.xml
+++ b/app/src/main/res/drawable/bg_bubble_idle.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#FF6750A4" />
+</shape>

--- a/app/src/main/res/drawable/bg_bubble_processing.xml
+++ b/app/src/main/res/drawable/bg_bubble_processing.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#FF7D5260" />
+</shape>

--- a/app/src/main/res/drawable/bg_bubble_recording.xml
+++ b/app/src/main/res/drawable/bg_bubble_recording.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#FFB3261E" />
+</shape>

--- a/app/src/main/res/drawable/bg_bubble_recording.xml
+++ b/app/src/main/res/drawable/bg_bubble_recording.xml
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="oval">
-    <solid android:color="#FFB3261E" />
-</shape>
+<!-- Recording: a red disc with a bright ring so the live state reads at a
+     glance even without the stop-square icon. The ring is the recording-only
+     indicator; idle/processing backgrounds stay plain. -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="#FFB3261E" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="@android:color/transparent" />
+            <stroke
+                android:width="3dp"
+                android:color="#FFFFB4AB" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/ic_add.xml
+++ b/app/src/main/res/drawable/ic_add.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_copy.xml
+++ b/app/src/main/res/drawable/ic_copy.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M16,1L4,1c-1.1,0 -2,0.9 -2,2v14h2L4,3h12L16,1zM19,5L8,5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h11c1.1,0 2,-0.9 2,-2L21,7c0,-1.1 -0.9,-2 -2,-2zM19,21L8,21L8,7h11v14z" />
+</vector>

--- a/app/src/main/res/drawable/ic_edit.xml
+++ b/app/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z" />
+</vector>

--- a/app/src/main/res/drawable/ic_history.xml
+++ b/app/src/main/res/drawable/ic_history.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M13,3c-4.97,0 -9,4.03 -9,9L1,12l3.89,3.89 0.07,0.14L9,12L6,12c0,-3.87 3.13,-7 7,-7s7,3.13 7,7 -3.13,7 -7,7c-1.93,0 -3.68,-0.79 -4.94,-2.06l-1.42,1.42C8.27,19.99 10.51,21 13,21c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9zM12,8v5l4.28,2.54 0.72,-1.21 -3.5,-2.08L13.5,8L12,8z" />
+</vector>

--- a/app/src/main/res/drawable/ic_stop.xml
+++ b/app/src/main/res/drawable/ic_stop.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7,7h10v10H7z" />
+</vector>

--- a/app/src/main/res/layout/activity_custom_words.xml
+++ b/app/src/main/res/layout/activity_custom_words.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="@string/custom_words_title" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="12dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/custom_words_desc"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+        <TextView
+            android:id="@+id/txt_custom_words_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAppearance="?attr/textAppearanceBodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginTop="4dp">
+
+            <TextView
+                android:id="@+id/txt_custom_words_count"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textAppearance="?attr/textAppearanceLabelMedium"
+                android:textColor="?attr/colorOnSurfaceVariant" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_custom_words_help"
+                style="@style/Widget.Material3.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/custom_words_help_title" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/custom_words_empty"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:text="@string/custom_words_empty"
+        android:textAppearance="?attr/textAppearanceBodyLarge"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        android:visibility="gone" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/custom_words_list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingBottom="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_custom_words_add"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginEnd="8dp"
+            app:icon="@drawable/ic_add"
+            android:text="@string/custom_words_add" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_custom_words_import"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/custom_words_import" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_history.xml
+++ b/app/src/main/res/layout/activity_history.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="@string/history_title" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <TextView
+        android:id="@+id/history_empty"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:text="@string/history_empty"
+        android:textAppearance="?attr/textAppearanceBodyLarge"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        android:visibility="gone" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/history_list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:padding="16dp" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_clear_all"
+        style="@style/Widget.Material3.Button.TextButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:text="@string/history_clear_all"
+        android:textColor="?attr/colorError" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -238,6 +238,13 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:text="@string/btn_models"/>
+
+                    <Button
+                        android:id="@+id/btn_custom_words"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/btn_custom_words"/>
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
@@ -629,7 +636,243 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
-            <!-- 7. Benchmark card: measures the active model's speed on this
+            <!-- 7. Floating mic bubble card -->
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                app:contentPadding="16dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:layout_marginBottom="8dp">
+
+                        <ImageView
+                            android:layout_width="24dp"
+                            android:layout_height="24dp"
+                            android:src="@drawable/ic_mic"
+                            android:contentDescription="@string/section_bubble"
+                            app:tint="?attr/colorPrimary"
+                            android:layout_marginEnd="12dp"/>
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/section_bubble"
+                            android:textAppearance="?attr/textAppearanceTitleLarge"/>
+                    </LinearLayout>
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/desc_bubble"
+                        android:textAppearance="?attr/textAppearanceBodyMedium"
+                        android:textColor="?attr/colorOnSurfaceVariant"
+                        android:layout_marginBottom="16dp"/>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/bubble_enable"
+                            android:textAppearance="?attr/textAppearanceBodyLarge"/>
+
+                        <com.google.android.material.materialswitch.MaterialSwitch
+                            android:id="@+id/switch_bubble"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"/>
+                    </LinearLayout>
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- 8. Accessibility direct insertion card -->
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                app:contentPadding="16dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:layout_marginBottom="8dp">
+
+                        <ImageView
+                            android:layout_width="24dp"
+                            android:layout_height="24dp"
+                            android:src="@drawable/ic_settings"
+                            android:contentDescription="@string/section_a11y"
+                            app:tint="?attr/colorPrimary"
+                            android:layout_marginEnd="12dp"/>
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/section_a11y"
+                            android:textAppearance="?attr/textAppearanceTitleLarge"/>
+                    </LinearLayout>
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/desc_a11y"
+                        android:textAppearance="?attr/textAppearanceBodyMedium"
+                        android:textColor="?attr/colorOnSurfaceVariant"
+                        android:layout_marginBottom="16dp"/>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/a11y_enable"
+                            android:textAppearance="?attr/textAppearanceBodyLarge"/>
+
+                        <com.google.android.material.materialswitch.MaterialSwitch
+                            android:id="@+id/switch_a11y"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"/>
+                    </LinearLayout>
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- 9. Transcription history card -->
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                app:contentPadding="16dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:layout_marginBottom="8dp">
+
+                        <ImageView
+                            android:layout_width="24dp"
+                            android:layout_height="24dp"
+                            android:src="@drawable/ic_history"
+                            android:contentDescription="@string/section_history"
+                            app:tint="?attr/colorPrimary"
+                            android:layout_marginEnd="12dp"/>
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/section_history"
+                            android:textAppearance="?attr/textAppearanceTitleLarge"/>
+                    </LinearLayout>
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btn_history"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/btn_history"
+                        android:layout_marginBottom="16dp"/>
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/setting_history_retention"
+                        android:textAppearance="?attr/textAppearanceBodyLarge"/>
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/setting_history_retention_desc"
+                        android:textAppearance="?attr/textAppearanceBodySmall"
+                        android:textColor="?attr/colorOnSurfaceVariant"
+                        android:layout_marginTop="2dp"/>
+
+                    <RadioGroup
+                        android:id="@+id/rg_retention"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:layout_marginTop="4dp">
+
+                        <RadioButton
+                            android:id="@+id/rb_ret_off"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/retention_off"/>
+
+                        <RadioButton
+                            android:id="@+id/rb_ret_10"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:text="@string/retention_10"/>
+
+                        <RadioButton
+                            android:id="@+id/rb_ret_25"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:text="@string/retention_25"/>
+
+                        <RadioButton
+                            android:id="@+id/rb_ret_50"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:text="@string/retention_50"/>
+
+                        <RadioButton
+                            android:id="@+id/rb_ret_100"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:text="@string/retention_100"/>
+
+                        <RadioButton
+                            android:id="@+id/rb_ret_unlimited"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:text="@string/retention_unlimited"/>
+                    </RadioGroup>
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- 10. Benchmark card: measures the active model's speed on this
                  device against a short bundled speech clip. -->
             <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -697,6 +697,99 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"/>
                     </LinearLayout>
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/bubble_unload_title"
+                        android:textAppearance="?attr/textAppearanceBodyLarge"
+                        android:layout_marginTop="16dp"/>
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/bubble_unload_desc"
+                        android:textAppearance="?attr/textAppearanceBodySmall"
+                        android:textColor="?attr/colorOnSurfaceVariant"
+                        android:layout_marginTop="2dp"/>
+
+                    <RadioGroup
+                        android:id="@+id/rg_bubble_unload"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:layout_marginTop="4dp">
+
+                        <RadioButton
+                            android:id="@+id/rb_unload_never"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/bubble_unload_never"/>
+
+                        <RadioButton
+                            android:id="@+id/rb_unload_5"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:text="@string/bubble_unload_5"/>
+
+                        <RadioButton
+                            android:id="@+id/rb_unload_15"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:text="@string/bubble_unload_15"/>
+
+                        <RadioButton
+                            android:id="@+id/rb_unload_30"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:text="@string/bubble_unload_30"/>
+                    </RadioGroup>
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/bubble_size_title"
+                        android:textAppearance="?attr/textAppearanceBodyLarge"
+                        android:layout_marginTop="16dp"/>
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/bubble_size_desc"
+                        android:textAppearance="?attr/textAppearanceBodySmall"
+                        android:textColor="?attr/colorOnSurfaceVariant"
+                        android:layout_marginTop="2dp"/>
+
+                    <RadioGroup
+                        android:id="@+id/rg_bubble_size"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:layout_marginTop="4dp">
+
+                        <RadioButton
+                            android:id="@+id/rb_size_small"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/bubble_size_small"/>
+
+                        <RadioButton
+                            android:id="@+id/rb_size_medium"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:text="@string/bubble_size_medium"/>
+
+                        <RadioButton
+                            android:id="@+id/rb_size_large"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:text="@string/bubble_size_large"/>
+                    </RadioGroup>
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/bubble_overlay.xml
+++ b/app/src/main/res/layout/bubble_overlay.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/bubble_root"
     android:layout_width="56dp"
     android:layout_height="56dp"
     android:background="@drawable/bg_bubble_idle"
-    android:contentDescription="@string/bubble_idle"
-    android:padding="14dp">
+    android:contentDescription="@string/bubble_idle">
 
     <ImageView
         android:id="@+id/bubble_icon"
@@ -14,4 +14,15 @@
         android:src="@drawable/ic_mic"
         android:importantForAccessibility="no"
         android:tint="@android:color/white" />
+
+    <ProgressBar
+        android:id="@+id/bubble_progress"
+        style="?android:attr/progressBarStyleSmall"
+        android:layout_width="28dp"
+        android:layout_height="28dp"
+        android:layout_gravity="center"
+        android:indeterminate="true"
+        android:indeterminateTint="@android:color/white"
+        android:importantForAccessibility="no"
+        android:visibility="gone" />
 </FrameLayout>

--- a/app/src/main/res/layout/bubble_overlay.xml
+++ b/app/src/main/res/layout/bubble_overlay.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="56dp"
+    android:layout_height="56dp"
+    android:background="@drawable/bg_bubble_idle"
+    android:contentDescription="@string/bubble_idle"
+    android:padding="14dp">
+
+    <ImageView
+        android:id="@+id/bubble_icon"
+        android:layout_width="28dp"
+        android:layout_height="28dp"
+        android:layout_gravity="center"
+        android:src="@drawable/ic_mic"
+        android:importantForAccessibility="no"
+        android:tint="@android:color/white" />
+</FrameLayout>

--- a/app/src/main/res/layout/item_custom_word.xml
+++ b/app/src/main/res/layout/item_custom_word.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:minHeight="48dp"
+    android:paddingTop="4dp"
+    android:paddingBottom="4dp">
+
+    <TextView
+        android:id="@+id/custom_word_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:textAppearance="?attr/textAppearanceBodyLarge"
+        android:maxLines="2"
+        android:ellipsize="end" />
+
+    <ImageButton
+        android:id="@+id/custom_word_edit"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/custom_words_edit"
+        android:src="@drawable/ic_edit"
+        app:tint="?attr/colorOnSurfaceVariant" />
+
+    <ImageButton
+        android:id="@+id/custom_word_delete"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/custom_words_delete"
+        android:src="@drawable/ic_delete"
+        app:tint="?attr/colorOnSurfaceVariant" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_history.xml
+++ b/app/src/main/res/layout/item_history.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="8dp"
+    app:contentPadding="12dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/history_item_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBodyLarge"
+            android:maxLines="4"
+            android:ellipsize="end" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginTop="8dp">
+
+            <TextView
+                android:id="@+id/history_item_meta"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textAppearance="?attr/textAppearanceBodySmall"
+                android:textColor="?attr/colorOnSurfaceVariant" />
+
+            <ImageButton
+                android:id="@+id/history_item_copy"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/history_copy"
+                android:src="@drawable/ic_copy"
+                app:tint="?attr/colorOnSurfaceVariant" />
+
+            <ImageButton
+                android:id="@+id/history_item_delete"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/history_delete"
+                android:src="@drawable/ic_delete"
+                app:tint="?attr/colorOnSurfaceVariant" />
+        </LinearLayout>
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -79,6 +79,34 @@
     <string name="models_threads_desc">Threads für die Transkription. „Automatisch“ wählt einen Wert passend zur CPU dieses Geräts. Ist die Transkription langsam, probiere andere Werte; mehr Threads sind nicht immer schneller.</string>
     <string name="models_threads_auto">Automatisch</string>
 
+    <!-- Custom words (Whisper recognition bias) -->
+    <string name="btn_custom_words">Benutzerdefinierte Wörter</string>
+    <string name="custom_words_title">Benutzerdefinierte Wörter</string>
+    <string name="custom_words_desc">Füge Namen, Fachbegriffe oder ungewöhnliche Wörter hinzu, um die Erkennung zu verbessern. Whisper-Modelle erhalten sie als Hinweis; andere Modelle ignorieren sie.</string>
+    <string name="custom_words_active_model">Aktives Modell: %1$s</string>
+    <string name="custom_words_builtin">integriert</string>
+    <string name="custom_words_not_whisper">Das aktive Modell ist kein Whisper-Modell und ignoriert möglicherweise benutzerdefinierte Wörter.</string>
+    <string name="custom_words_help_title">So funktioniert es</string>
+    <string name="custom_words_help_body">Benutzerdefinierte Wörter werden an Whisper-Modelle als Anfangs-Prompt übergeben und lenken die Erkennung in Richtung deiner Namen und Begriffe. Auf andere Modelle haben sie keine Wirkung.\n\nPrivatsphäre: Die Liste wird nur im privaten Speicher der App gespeichert und ausschließlich auf diesem Gerät verwendet, um das Offline-Modell zu steuern. Sie wird nie hochgeladen oder geteilt.</string>
+    <string name="custom_words_empty">Noch keine benutzerdefinierten Wörter</string>
+    <string name="custom_words_add">Wort hinzufügen</string>
+    <string name="custom_words_add_hint">Wort oder Phrase</string>
+    <string name="custom_words_edit">Wort bearbeiten</string>
+    <string name="custom_words_delete">Wort löschen</string>
+    <string name="custom_words_import">Liste importieren</string>
+    <string name="custom_words_import_hint">Ein Wort pro Zeile</string>
+    <string name="custom_words_saved">Gespeichert</string>
+    <string name="custom_words_duplicate">Bereits in der Liste</string>
+    <string name="custom_words_empty_input">Gib ein Wort ein</string>
+    <string name="custom_words_too_long">Zu lang (max. %1$d Zeichen)</string>
+    <string name="custom_words_limit">Liste ist voll (max. %1$d Wörter)</string>
+    <string name="custom_words_import_done">%1$d Wörter importiert</string>
+    <string name="custom_words_import_none">Nichts Neues zu importieren</string>
+    <plurals name="custom_words_count">
+        <item quantity="one">%1$d Wort</item>
+        <item quantity="other">%1$d Wörter</item>
+    </plurals>
+
     <string name="section_benchmark">Benchmark</string>
     <string name="desc_benchmark">Misst, wie schnell das aktive Modell auf diesem Gerät transkribiert, anhand einer integrierten englischen Testaufnahme (11 s).</string>
     <string name="btn_benchmark">Benchmark starten</string>
@@ -104,5 +132,56 @@
     <string name="voice_test_failed">Spracheingabe konnte auf diesem Gerät nicht gestartet werden.</string>
 
     <string name="voice_help_title">Einrichtung der Spracheingabe</string>
-    <string name="voice_help_body">So funktioniert es\n• Öffne eine beliebige App und tippe auf das Mikrofon einer unterstützten Tastatur/App. Ein kleines Panel erscheint, du sprichst, tippst zum Stoppen, und der Text wird eingefügt. (Aktiviere „Auto-Stopp bei Stille“ in den Einstellungen, damit es von selbst stoppt.)\n\nWelche Tastaturen öffnen das Sprach-Panel\n• Microsoft SwiftKey (nicht Open Source) und die Sprachsuche auf Websites öffnen das Panel direkt.\n• AnySoftKeyboard ist der Open-Source-Weg zum Panel: Seine Mikrofontaste öffnet es, solange auf deinem System keine Sprach-Tastatur aktiviert ist.\n\nAndere Open-Source-Tastaturen\n• HeliBoard, FlorisBoard, OpenBoard, Fossify Keyboard und Unexpected Keyboard öffnen das Panel nicht: Ihre Mikrofontaste wechselt stattdessen zur „Offline Voice Input“-Tastatur. Aktiviere sie einmal (siehe „Alternative: Sprach-Tastatur“), sprich dort und kehre über deren Tastaturwechsel-Taste zurück. FUTO Keyboard bringt eine eigene Spracheingabe mit.\n• Gboard nutzt nur Googles eigene Spracheingabe und kann diese App gar nicht verwenden.\n\nFalls SwiftKeys eigene Spracheingabe öffnet\n• Einstellungen → Rich-Eingabe → „Multimodale Spracheingabe“ deaktivieren.\n• Tippe dann erneut auf das Mikrofon und wähle „Offline Voice Input“.\n\nFalls Android fragt, welche App verwendet werden soll\n• Wähle „Offline Voice Input“ und tippe auf „Immer“.\n\nFalls immer eine andere App öffnet\n• Öffne Einstellungen → Apps → diese App → „Standardmäßig öffnen“ → Standardeinstellungen löschen, und versuche es erneut.</string>
+    <string name="voice_help_body">So funktioniert es\n• Öffne eine beliebige App und tippe auf das Mikrofon einer unterstützten Tastatur/App. Ein kleines Panel erscheint, du sprichst, tippst zum Stoppen, und der Text wird eingefügt. (Aktiviere „Auto-Stopp bei Stille" in den Einstellungen, damit es von selbst stoppt.)\n\nWelche Tastaturen öffnen das Sprach-Panel\n• Microsoft SwiftKey (nicht Open Source) und die Sprachsuche auf Websites öffnen das Panel direkt.\n• AnySoftKeyboard ist der Open-Source-Weg zum Panel: Seine Mikrofontaste öffnet es, solange auf deinem System keine Sprach-Tastatur aktiviert ist.\n\nAndere Open-Source-Tastaturen\n• HeliBoard, FlorisBoard, OpenBoard, Fossify Keyboard und Unexpected Keyboard öffnen das Panel nicht: Ihre Mikrofontaste wechselt stattdessen zur „Offline Voice Input"-Tastatur. Aktiviere sie einmal (siehe „Alternative: Sprach-Tastatur"), sprich dort und kehre über deren Tastaturwechsel-Taste zurück. FUTO Keyboard bringt eine eigene Spracheingabe mit.\n• Gboard nutzt nur Googles eigene Spracheingabe und kann diese App gar nicht verwenden.\n\nFalls SwiftKeys eigene Spracheingabe öffnet\n• Einstellungen → Rich-Eingabe → „Multimodale Spracheingabe" deaktivieren.\n• Tippe dann erneut auf das Mikrofon und wähle „Offline Voice Input".\n\nFalls Android fragt, welche App verwendet werden soll\n• Wähle „Offline Voice Input" und tippe auf „Immer".\n\nFalls immer eine andere App öffnet\n• Öffne Einstellungen → Apps → diese App → „Standardmäßig öffnen" → Standardeinstellungen löschen, und versuche es erneut.</string>
+
+    <string name="section_bubble">Schwebende Mikrofon-Blase</string>
+    <string name="desc_bubble">Zeigt eine verschiebbare Mikrofon-Blase auf dem Bildschirm. Tippe darauf, um aufzunehmen; die Transkription wird in die Zwischenablage kopiert und im Verlauf gespeichert.</string>
+    <string name="bubble_enable">Mikrofon-Blase anzeigen</string>
+    <string name="bubble_need_overlay">Bitte zuerst „Über anderen Apps einblenden" erlauben.</string>
+    <string name="bubble_need_mic">Mikrofonberechtigung erforderlich.</string>
+    <string name="bubble_idle">Mikrofon-Blase – tippen zum Aufnehmen</string>
+    <string name="bubble_recording">Aufnahme – tippen zum Stoppen</string>
+    <string name="bubble_processing">Verarbeitung…</string>
+    <string name="bubble_copied">In die Zwischenablage kopiert</string>
+    <string name="bubble_inserted">In Textfeld eingefügt</string>
+    <string name="bubble_channel_name">Mikrofon-Blase</string>
+    <string name="bubble_notification_title">Mikrofon-Blase aktiv</string>
+    <string name="bubble_notification_text">Tippe auf die Blase, um Sprache aufzunehmen</string>
+    <string name="bubble_stop_recording">Aufnahme stoppen</string>
+    <string name="bubble_hide">Blase ausblenden</string>
+
+    <string name="section_a11y">Direktes Einfügen (optional)</string>
+    <string name="desc_a11y">Wenn aktiviert, werden Transkriptionen der Mikrofon-Blase direkt in das fokussierte Textfeld über einen Bedienungshilfe-Dienst eingefügt. Schlägt das Einfügen fehl, wird der Text stattdessen in die Zwischenablage kopiert. Dieser Dienst schreibt nur in das fokussierte bearbeitbare Feld; er liest oder speichert niemals Feldinhalte und überspringt Passwortfelder.</string>
+    <string name="a11y_enable">Direktes Einfügen aktivieren</string>
+    <string name="a11y_consent_title">Bedienungshilfe-Berechtigung</string>
+    <string name="a11y_consent_body">Das direkte Einfügen nutzt einen Android-Bedienungshilfe-Dienst, um transkribierten Text in das fokussierte Textfeld einzugeben.\n\nWas er tut:\n• Schreibt transkribierten Text in das aktuell fokussierte, sichtbare bearbeitbare Feld\n• Überspringt Passwort- und sensible Felder\n\nWas er NICHT tut:\n• Feldinhalte lesen oder speichern\n• Vorhandenen Text überschreiben (er fügt am Cursor an)\n• Auf nicht fokussierte Felder zugreifen\n\nDu wirst zu den Bedienungshilfe-Einstellungen weitergeleitet, um den Dienst zu aktivieren.</string>
+    <string name="a11y_consent_accept">Verstanden, fortfahren</string>
+    <string name="a11y_service_description">Fügt transkribierte Sprache in das fokussierte Textfeld ein. Schreibt nur Text; liest niemals Feldinhalte.</string>
+    <string name="a11y_not_enabled">Bedienungshilfe-Dienst nicht aktiviert. Öffne die Bedienungshilfe-Einstellungen, um ihn einzuschalten.</string>
+
+    <string name="section_history">Transkriptionsverlauf</string>
+    <string name="history_title">Verlauf</string>
+    <string name="history_empty">Noch keine Transkriptionen</string>
+    <string name="history_clear_all">Alle löschen</string>
+    <string name="history_clear_title">Verlauf löschen?</string>
+    <string name="history_clear_body">Alle gespeicherten Transkriptionen werden dauerhaft gelöscht.</string>
+    <string name="history_clear_confirm">Alle löschen</string>
+    <string name="history_copied">Kopiert</string>
+    <string name="history_copy">Kopieren</string>
+    <string name="history_delete">Löschen</string>
+    <string name="history_meta">%1$s · %2$s</string>
+    <string name="history_source_bubble">Blase</string>
+    <string name="history_source_popup">Sprach-Popup</string>
+    <string name="history_source_ime">Sprach-Tastatur</string>
+    <string name="history_source_file">Audiodatei</string>
+    <string name="btn_history">Verlauf anzeigen</string>
+
+    <string name="setting_history_retention">Verlaufsaufbewahrung</string>
+    <string name="setting_history_retention_desc">Wie viele Transkriptionen behalten werden. Ältere Einträge werden automatisch gelöscht.</string>
+    <string name="retention_off">Aus</string>
+    <string name="retention_10">10</string>
+    <string name="retention_25">25</string>
+    <string name="retention_50">50</string>
+    <string name="retention_100">100</string>
+    <string name="retention_unlimited">Unbegrenzt</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -149,6 +149,19 @@
     <string name="bubble_notification_text">Tippe auf die Blase, um Sprache aufzunehmen</string>
     <string name="bubble_stop_recording">Aufnahme stoppen</string>
     <string name="bubble_hide">Blase ausblenden</string>
+    <string name="bubble_loading">Modell wird geladen…</string>
+    <string name="bubble_load_failed">Modell konnte nicht geladen werden. Bitte erneut versuchen.</string>
+    <string name="bubble_unload_title">Bei Inaktivität entladen</string>
+    <string name="bubble_unload_desc">Um Speicher und Akku zu sparen, wird das Modell entladen, wenn die Blase eine Weile inaktiv war. Die Blase bleibt sichtbar und nutzbar; die nächste Aufnahme muss das Modell eventuell kurz neu laden.</string>
+    <string name="bubble_unload_never">Nie</string>
+    <string name="bubble_unload_5">5 Min</string>
+    <string name="bubble_unload_15">15 Min</string>
+    <string name="bubble_unload_30">30 Min</string>
+    <string name="bubble_size_title">Blasengröße</string>
+    <string name="bubble_size_desc">Wie groß die schwebende Blase auf dem Bildschirm erscheint.</string>
+    <string name="bubble_size_small">Klein</string>
+    <string name="bubble_size_medium">Mittel</string>
+    <string name="bubble_size_large">Groß</string>
 
     <string name="section_a11y">Direktes Einfügen (optional)</string>
     <string name="desc_a11y">Wenn aktiviert, werden Transkriptionen der Mikrofon-Blase direkt in das fokussierte Textfeld über einen Bedienungshilfe-Dienst eingefügt. Schlägt das Einfügen fehl, wird der Text stattdessen in die Zwischenablage kopiert. Dieser Dienst schreibt nur in das fokussierte bearbeitbare Feld; er liest oder speichert niemals Feldinhalte und überspringt Passwortfelder.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -79,6 +79,34 @@
     <string name="models_threads_desc">Hilos usados para la transcripción. «Automático» elige un valor según la CPU de este dispositivo. Si la transcripción es lenta, prueba otros valores; más hilos no siempre es más rápido.</string>
     <string name="models_threads_auto">Automático</string>
 
+    <!-- Custom words (Whisper recognition bias) -->
+    <string name="btn_custom_words">Palabras personalizadas</string>
+    <string name="custom_words_title">Palabras personalizadas</string>
+    <string name="custom_words_desc">Añade nombres, términos técnicos o palabras poco comunes para mejorar el reconocimiento. Los modelos Whisper las reciben como una pista; otros modelos las ignoran.</string>
+    <string name="custom_words_active_model">Modelo activo: %1$s</string>
+    <string name="custom_words_builtin">integrado</string>
+    <string name="custom_words_not_whisper">El modelo activo no es un modelo Whisper, por lo que puede ignorar las palabras personalizadas.</string>
+    <string name="custom_words_help_title">Cómo funciona</string>
+    <string name="custom_words_help_body">Las palabras personalizadas se pasan a los modelos Whisper como un prompt inicial, sesgando el reconocimiento hacia tus nombres y términos. No tienen efecto en otros modelos.\n\nPrivacidad: la lista se almacena solo en el almacenamiento privado de esta app y se usa únicamente en este dispositivo para guiar el modelo sin conexión. Nunca se sube ni se comparte.</string>
+    <string name="custom_words_empty">Aún no hay palabras personalizadas</string>
+    <string name="custom_words_add">Añadir palabra</string>
+    <string name="custom_words_add_hint">Palabra o frase</string>
+    <string name="custom_words_edit">Editar palabra</string>
+    <string name="custom_words_delete">Eliminar palabra</string>
+    <string name="custom_words_import">Importar lista</string>
+    <string name="custom_words_import_hint">Una palabra por línea</string>
+    <string name="custom_words_saved">Guardado</string>
+    <string name="custom_words_duplicate">Ya está en la lista</string>
+    <string name="custom_words_empty_input">Escribe una palabra</string>
+    <string name="custom_words_too_long">Demasiado largo (máx. %1$d caracteres)</string>
+    <string name="custom_words_limit">La lista está llena (máx. %1$d palabras)</string>
+    <string name="custom_words_import_done">%1$d palabras importadas</string>
+    <string name="custom_words_import_none">Nada nuevo que importar</string>
+    <plurals name="custom_words_count">
+        <item quantity="one">%1$d palabra</item>
+        <item quantity="other">%1$d palabras</item>
+    </plurals>
+
     <string name="section_benchmark">Prueba de rendimiento</string>
     <string name="desc_benchmark">Mide la velocidad de transcripción del modelo activo en este dispositivo usando una grabación de prueba en inglés integrada (11 s).</string>
     <string name="btn_benchmark">Iniciar prueba</string>
@@ -105,4 +133,55 @@
 
     <string name="voice_help_title">Configuración de la entrada de voz</string>
     <string name="voice_help_body">Cómo usarlo\n• Abre cualquier app y toca el micrófono de un teclado/una app compatible. Aparece un panel pequeño, hablas, tocas para detener y el texto se inserta. (Activa «Parada automática tras silencio» en los ajustes para que se detenga solo.)\n\nQué teclados abren el panel de voz\n• Microsoft SwiftKey (no es de código abierto) y la búsqueda por voz de los sitios web abren el panel directamente.\n• AnySoftKeyboard es la vía de código abierto al panel: su tecla de micrófono lo abre mientras no haya ningún teclado de voz activado en tu sistema.\n\nOtros teclados de código abierto\n• HeliBoard, FlorisBoard, OpenBoard, Fossify Keyboard y Unexpected Keyboard no abren el panel: su tecla de micrófono cambia al teclado «Offline Voice Input». Actívalo una vez (mira «Alternativa: teclado de voz»), habla allí y vuelve con su tecla de cambio de teclado. FUTO Keyboard trae su propia entrada de voz.\n• Gboard solo usa la entrada de voz de Google y no puede usar esta app en absoluto.\n\nSi se abre la entrada de voz propia de SwiftKey\n• Ajustes → Entrada enriquecida → desactiva «Entrada de voz multimodal».\n• Luego toca de nuevo el micrófono y elige «Offline Voice Input».\n\nSi Android pregunta qué app usar\n• Elige «Offline Voice Input» y toca «Siempre».\n\nSi siempre se abre otra app\n• Abre Ajustes → Aplicaciones → esa app → «Abrir de forma predeterminada» → Borrar valores predeterminados, e inténtalo de nuevo.</string>
+
+    <string name="section_bubble">Burbuja de micrófono flotante</string>
+    <string name="desc_bubble">Muestra una burbuja de micrófono arrastrable en pantalla. Tócala para grabar; la transcripción se copia al portapapeles y se guarda en el historial.</string>
+    <string name="bubble_enable">Mostrar burbuja de micrófono</string>
+    <string name="bubble_need_overlay">Primero permite mostrar sobre otras aplicaciones.</string>
+    <string name="bubble_need_mic">Se requiere permiso de micrófono.</string>
+    <string name="bubble_idle">Burbuja de micrófono – toca para grabar</string>
+    <string name="bubble_recording">Grabando – toca para detener</string>
+    <string name="bubble_processing">Procesando…</string>
+    <string name="bubble_copied">Copiado al portapapeles</string>
+    <string name="bubble_inserted">Insertado en el campo de texto</string>
+    <string name="bubble_channel_name">Burbuja de micrófono</string>
+    <string name="bubble_notification_title">Burbuja de micrófono activa</string>
+    <string name="bubble_notification_text">Toca la burbuja para grabar voz</string>
+    <string name="bubble_stop_recording">Detener grabación</string>
+    <string name="bubble_hide">Ocultar burbuja</string>
+
+    <string name="section_a11y">Inserción directa (opcional)</string>
+    <string name="desc_a11y">Cuando está activado, las transcripciones de la burbuja se insertan directamente en el campo de texto enfocado mediante un servicio de accesibilidad. Si falla, el texto se copia al portapapeles. Este servicio solo escribe en el campo editable enfocado; nunca lee ni almacena contenido de campos y omite campos de contraseña.</string>
+    <string name="a11y_enable">Activar inserción directa</string>
+    <string name="a11y_consent_title">Permiso de accesibilidad</string>
+    <string name="a11y_consent_body">La inserción directa usa un servicio de accesibilidad de Android para escribir el texto transcrito en el campo de texto enfocado.\n\nLo que hace:\n• Escribe el texto transcrito en el campo editable visible y enfocado\n• Omite campos de contraseña y sensibles\n\nLo que NO hace:\n• Leer o almacenar contenido de campos\n• Sobrescribir texto existente (añade en el cursor)\n• Acceder a campos no enfocados\n\nSerás redirigido a los ajustes de accesibilidad para activar el servicio.</string>
+    <string name="a11y_consent_accept">Entendido, continuar</string>
+    <string name="a11y_service_description">Inserta voz transcrita en el campo de texto enfocado. Solo escribe; nunca lee contenido.</string>
+    <string name="a11y_not_enabled">Servicio de accesibilidad no activado. Abre los ajustes de accesibilidad para activarlo.</string>
+
+    <string name="section_history">Historial de transcripciones</string>
+    <string name="history_title">Historial</string>
+    <string name="history_empty">Aún no hay transcripciones</string>
+    <string name="history_clear_all">Borrar todo</string>
+    <string name="history_clear_title">¿Borrar historial?</string>
+    <string name="history_clear_body">Todas las transcripciones guardadas se eliminarán permanentemente.</string>
+    <string name="history_clear_confirm">Eliminar todo</string>
+    <string name="history_copied">Copiado</string>
+    <string name="history_copy">Copiar</string>
+    <string name="history_delete">Eliminar</string>
+    <string name="history_meta">%1$s · %2$s</string>
+    <string name="history_source_bubble">Burbuja</string>
+    <string name="history_source_popup">Panel de voz</string>
+    <string name="history_source_ime">Teclado de voz</string>
+    <string name="history_source_file">Archivo de audio</string>
+    <string name="btn_history">Ver historial</string>
+
+    <string name="setting_history_retention">Retención del historial</string>
+    <string name="setting_history_retention_desc">Cuántas transcripciones conservar. Las entradas antiguas se eliminan automáticamente.</string>
+    <string name="retention_off">Desactivado</string>
+    <string name="retention_10">10</string>
+    <string name="retention_25">25</string>
+    <string name="retention_50">50</string>
+    <string name="retention_100">100</string>
+    <string name="retention_unlimited">Ilimitado</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -149,6 +149,19 @@
     <string name="bubble_notification_text">Toca la burbuja para grabar voz</string>
     <string name="bubble_stop_recording">Detener grabación</string>
     <string name="bubble_hide">Ocultar burbuja</string>
+    <string name="bubble_loading">Cargando modelo…</string>
+    <string name="bubble_load_failed">No se pudo cargar el modelo. Inténtalo de nuevo.</string>
+    <string name="bubble_unload_title">Descargar en inactividad</string>
+    <string name="bubble_unload_desc">Para ahorrar memoria y batería, descarga el modelo cuando la burbuja lleva un rato inactiva. La burbuja sigue visible y usable; la próxima grabación puede tardar un momento en recargar el modelo.</string>
+    <string name="bubble_unload_never">Nunca</string>
+    <string name="bubble_unload_5">5 min</string>
+    <string name="bubble_unload_15">15 min</string>
+    <string name="bubble_unload_30">30 min</string>
+    <string name="bubble_size_title">Tamaño de la burbuja</string>
+    <string name="bubble_size_desc">Qué tan grande aparece la burbuja flotante en pantalla.</string>
+    <string name="bubble_size_small">Pequeño</string>
+    <string name="bubble_size_medium">Mediano</string>
+    <string name="bubble_size_large">Grande</string>
 
     <string name="section_a11y">Inserción directa (opcional)</string>
     <string name="desc_a11y">Cuando está activado, las transcripciones de la burbuja se insertan directamente en el campo de texto enfocado mediante un servicio de accesibilidad. Si falla, el texto se copia al portapapeles. Este servicio solo escribe en el campo editable enfocado; nunca lee ni almacena contenido de campos y omite campos de contraseña.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -149,6 +149,19 @@
     <string name="bubble_notification_text">Touchez la bulle pour enregistrer la voix</string>
     <string name="bubble_stop_recording">Arrêter l\'enregistrement</string>
     <string name="bubble_hide">Masquer la bulle</string>
+    <string name="bubble_loading">Chargement du modèle…</string>
+    <string name="bubble_load_failed">Impossible de charger le modèle. Veuillez réessayer.</string>
+    <string name="bubble_unload_title">Décharger si inactive</string>
+    <string name="bubble_unload_desc">Pour économiser la mémoire et la batterie, décharge le modèle quand la bulle est restée inactive un moment. La bulle reste visible et utilisable ; le prochain enregistrement peut prendre un instant pour recharger le modèle.</string>
+    <string name="bubble_unload_never">Jamais</string>
+    <string name="bubble_unload_5">5 min</string>
+    <string name="bubble_unload_15">15 min</string>
+    <string name="bubble_unload_30">30 min</string>
+    <string name="bubble_size_title">Taille de la bulle</string>
+    <string name="bubble_size_desc">La taille de la bulle flottante à l\'écran.</string>
+    <string name="bubble_size_small">Petite</string>
+    <string name="bubble_size_medium">Moyenne</string>
+    <string name="bubble_size_large">Grande</string>
 
     <string name="section_a11y">Insertion directe (optionnel)</string>
     <string name="desc_a11y">Lorsque activé, les transcriptions de la bulle micro sont insérées directement dans le champ de texte focalisé via un service d\'accessibilité. En cas d\'échec, le texte est copié dans le presse-papiers. Ce service écrit uniquement dans le champ modifiable focalisé ; il ne lit ni ne stocke le contenu des champs et ignore les champs de mot de passe.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -79,6 +79,34 @@
     <string name="models_threads_desc">Threads utilisés pour la transcription. « Automatique » choisit une valeur adaptée au processeur de cet appareil. Si la transcription est lente, essayez d\'autres valeurs ; plus de threads n\'est pas toujours plus rapide.</string>
     <string name="models_threads_auto">Automatique</string>
 
+    <!-- Custom words (Whisper recognition bias) -->
+    <string name="btn_custom_words">Mots personnalisés</string>
+    <string name="custom_words_title">Mots personnalisés</string>
+    <string name="custom_words_desc">Ajoutez des noms, des termes techniques ou des mots inhabituels pour améliorer la reconnaissance. Les modèles Whisper les reçoivent comme indice ; les autres modèles les ignorent.</string>
+    <string name="custom_words_active_model">Modèle actif : %1$s</string>
+    <string name="custom_words_builtin">intégré</string>
+    <string name="custom_words_not_whisper">Le modèle actif n\'est pas un modèle Whisper ; il peut donc ignorer les mots personnalisés.</string>
+    <string name="custom_words_help_title">Comment ça marche</string>
+    <string name="custom_words_help_body">Les mots personnalisés sont transmis aux modèles Whisper comme invite initiale, orientant la reconnaissance vers vos noms et termes. Ils n\'ont aucun effet sur les autres modèles.\n\nConfidentialité : la liste est stockée uniquement dans l\'espace privé de cette application et sert seulement sur cet appareil à guider le modèle hors ligne. Elle n\'est jamais envoyée ni partagée.</string>
+    <string name="custom_words_empty">Pas encore de mots personnalisés</string>
+    <string name="custom_words_add">Ajouter un mot</string>
+    <string name="custom_words_add_hint">Mot ou expression</string>
+    <string name="custom_words_edit">Modifier le mot</string>
+    <string name="custom_words_delete">Supprimer le mot</string>
+    <string name="custom_words_import">Importer une liste</string>
+    <string name="custom_words_import_hint">Un mot par ligne</string>
+    <string name="custom_words_saved">Enregistré</string>
+    <string name="custom_words_duplicate">Déjà dans la liste</string>
+    <string name="custom_words_empty_input">Saisissez un mot</string>
+    <string name="custom_words_too_long">Trop long (max %1$d caractères)</string>
+    <string name="custom_words_limit">Liste pleine (max %1$d mots)</string>
+    <string name="custom_words_import_done">%1$d mots importés</string>
+    <string name="custom_words_import_none">Rien de nouveau à importer</string>
+    <plurals name="custom_words_count">
+        <item quantity="one">%1$d mot</item>
+        <item quantity="other">%1$d mots</item>
+    </plurals>
+
     <string name="section_benchmark">Test de performance</string>
     <string name="desc_benchmark">Mesure la vitesse de transcription du modèle actif sur cet appareil à l\'aide d\'un enregistrement de test en anglais intégré (11 s).</string>
     <string name="btn_benchmark">Lancer le test</string>
@@ -105,4 +133,55 @@
 
     <string name="voice_help_title">Configuration de la saisie vocale</string>
     <string name="voice_help_body">Comment l\'utiliser\n• Ouvrez n\'importe quelle app et touchez le micro d\'un clavier/d\'une app pris en charge. Un petit panneau apparaît, vous parlez, touchez pour arrêter, et le texte est inséré. (Activez « Arrêt automatique après un silence » dans les paramètres pour qu\'il s\'arrête tout seul.)\n\nQuels claviers ouvrent le panneau vocal\n• Microsoft SwiftKey (non open source) et la recherche vocale des sites web ouvrent le panneau directement.\n• AnySoftKeyboard est la voie open source vers le panneau : sa touche micro l\'ouvre tant qu\'aucun clavier vocal n\'est activé sur votre système.\n\nAutres claviers open source\n• HeliBoard, FlorisBoard, OpenBoard, Fossify Keyboard et Unexpected Keyboard n\'ouvrent pas le panneau : leur touche micro bascule vers le clavier « Offline Voice Input ». Activez-le une fois (voir « Alternative : clavier vocal »), parlez, puis revenez avec sa touche de changement de clavier. FUTO Keyboard embarque sa propre saisie vocale.\n• Gboard n\'utilise que la saisie vocale de Google et ne peut pas du tout utiliser cette app.\n\nSi la saisie vocale de SwiftKey s\'ouvre à la place\n• Paramètres → Saisie riche → désactivez « Saisie vocale multimodale ».\n• Touchez ensuite à nouveau le micro et choisissez « Offline Voice Input ».\n\nSi Android demande quelle app utiliser\n• Choisissez « Offline Voice Input » et touchez « Toujours ».\n\nSi une autre app s\'ouvre toujours\n• Ouvrez Paramètres → Applications → cette app → « Ouvrir par défaut » → Effacer les valeurs par défaut, puis réessayez.</string>
+
+    <string name="section_bubble">Bulle micro flottante</string>
+    <string name="desc_bubble">Affiche une bulle micro déplaçable à l\'écran. Touchez-la pour enregistrer ; la transcription est copiée dans le presse-papiers et enregistrée dans l\'historique.</string>
+    <string name="bubble_enable">Afficher la bulle micro</string>
+    <string name="bubble_need_overlay">Veuillez d\'abord autoriser l\'affichage par-dessus d\'autres apps.</string>
+    <string name="bubble_need_mic">Autorisation du microphone requise.</string>
+    <string name="bubble_idle">Bulle micro – touchez pour enregistrer</string>
+    <string name="bubble_recording">Enregistrement – touchez pour arrêter</string>
+    <string name="bubble_processing">Traitement…</string>
+    <string name="bubble_copied">Copié dans le presse-papiers</string>
+    <string name="bubble_inserted">Inséré dans le champ de texte</string>
+    <string name="bubble_channel_name">Bulle micro</string>
+    <string name="bubble_notification_title">Bulle micro active</string>
+    <string name="bubble_notification_text">Touchez la bulle pour enregistrer la voix</string>
+    <string name="bubble_stop_recording">Arrêter l\'enregistrement</string>
+    <string name="bubble_hide">Masquer la bulle</string>
+
+    <string name="section_a11y">Insertion directe (optionnel)</string>
+    <string name="desc_a11y">Lorsque activé, les transcriptions de la bulle micro sont insérées directement dans le champ de texte focalisé via un service d\'accessibilité. En cas d\'échec, le texte est copié dans le presse-papiers. Ce service écrit uniquement dans le champ modifiable focalisé ; il ne lit ni ne stocke le contenu des champs et ignore les champs de mot de passe.</string>
+    <string name="a11y_enable">Activer l\'insertion directe</string>
+    <string name="a11y_consent_title">Autorisation d\'accessibilité</string>
+    <string name="a11y_consent_body">L\'insertion directe utilise un service d\'accessibilité Android pour taper le texte transcrit dans le champ de texte focalisé.\n\nCe qu\'il fait :\n• Écrit le texte transcrit dans le champ modifiable visible et focalisé\n• Ignore les champs de mot de passe et sensibles\n\nCe qu\'il ne fait PAS :\n• Lire ou stocker le contenu des champs\n• Écraser le texte existant (il ajoute au curseur)\n• Accéder aux champs non focalisés\n\nVous serez redirigé vers les paramètres d\'accessibilité pour activer le service.</string>
+    <string name="a11y_consent_accept">Je comprends, continuer</string>
+    <string name="a11y_service_description">Insère la voix transcrite dans le champ de texte focalisé. Écrit uniquement ; ne lit jamais le contenu.</string>
+    <string name="a11y_not_enabled">Service d\'accessibilité non activé. Ouvrez les paramètres d\'accessibilité pour l\'activer.</string>
+
+    <string name="section_history">Historique de transcription</string>
+    <string name="history_title">Historique</string>
+    <string name="history_empty">Aucune transcription pour l\'instant</string>
+    <string name="history_clear_all">Tout effacer</string>
+    <string name="history_clear_title">Effacer l\'historique ?</string>
+    <string name="history_clear_body">Toutes les transcriptions enregistrées seront définitivement supprimées.</string>
+    <string name="history_clear_confirm">Tout supprimer</string>
+    <string name="history_copied">Copié</string>
+    <string name="history_copy">Copier</string>
+    <string name="history_delete">Supprimer</string>
+    <string name="history_meta">%1$s · %2$s</string>
+    <string name="history_source_bubble">Bulle</string>
+    <string name="history_source_popup">Panneau vocal</string>
+    <string name="history_source_ime">Clavier vocal</string>
+    <string name="history_source_file">Fichier audio</string>
+    <string name="btn_history">Voir l\'historique</string>
+
+    <string name="setting_history_retention">Rétention de l\'historique</string>
+    <string name="setting_history_retention_desc">Nombre de transcriptions à conserver. Les entrées plus anciennes sont supprimées automatiquement.</string>
+    <string name="retention_off">Désactivé</string>
+    <string name="retention_10">10</string>
+    <string name="retention_25">25</string>
+    <string name="retention_50">50</string>
+    <string name="retention_100">100</string>
+    <string name="retention_unlimited">Illimité</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -149,6 +149,19 @@
     <string name="bubble_notification_text">Tocca la bolla per registrare la voce</string>
     <string name="bubble_stop_recording">Ferma registrazione</string>
     <string name="bubble_hide">Nascondi bolla</string>
+    <string name="bubble_loading">Caricamento modello…</string>
+    <string name="bubble_load_failed">Impossibile caricare il modello. Riprova.</string>
+    <string name="bubble_unload_title">Scarica se inattiva</string>
+    <string name="bubble_unload_desc">Per risparmiare memoria e batteria, scarica il modello quando la bolla è rimasta inattiva per un po\'. La bolla resta visibile e utilizzabile; la prossima registrazione potrebbe richiedere un momento per ricaricare il modello.</string>
+    <string name="bubble_unload_never">Mai</string>
+    <string name="bubble_unload_5">5 min</string>
+    <string name="bubble_unload_15">15 min</string>
+    <string name="bubble_unload_30">30 min</string>
+    <string name="bubble_size_title">Dimensione bolla</string>
+    <string name="bubble_size_desc">Quanto è grande la bolla fluttuante sullo schermo.</string>
+    <string name="bubble_size_small">Piccola</string>
+    <string name="bubble_size_medium">Media</string>
+    <string name="bubble_size_large">Grande</string>
 
     <string name="section_a11y">Inserimento diretto (opzionale)</string>
     <string name="desc_a11y">Quando attivato, le trascrizioni della bolla vengono inserite direttamente nel campo di testo focalizzato tramite un servizio di accessibilità. Se l\'inserimento fallisce, il testo viene copiato negli appunti. Questo servizio scrive solo nel campo modificabile focalizzato; non legge né memorizza il contenuto dei campi e salta i campi password.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -79,6 +79,34 @@
     <string name="models_threads_desc">Thread usati per la trascrizione. «Automatico» sceglie un valore in base alla CPU di questo dispositivo. Se la trascrizione è lenta, prova altri valori; più thread non è sempre più veloce.</string>
     <string name="models_threads_auto">Automatico</string>
 
+    <!-- Custom words (Whisper recognition bias) -->
+    <string name="btn_custom_words">Parole personalizzate</string>
+    <string name="custom_words_title">Parole personalizzate</string>
+    <string name="custom_words_desc">Aggiungi nomi, termini tecnici o parole insolite per migliorare il riconoscimento. I modelli Whisper li ricevono come suggerimento; gli altri modelli li ignorano.</string>
+    <string name="custom_words_active_model">Modello attivo: %1$s</string>
+    <string name="custom_words_builtin">integrato</string>
+    <string name="custom_words_not_whisper">Il modello attivo non è un modello Whisper, quindi potrebbe ignorare le parole personalizzate.</string>
+    <string name="custom_words_help_title">Come funziona</string>
+    <string name="custom_words_help_body">Le parole personalizzate vengono passate ai modelli Whisper come prompt iniziale, orientando il riconoscimento verso i tuoi nomi e termini. Non hanno effetto sugli altri modelli.\n\nPrivacy: l\'elenco è salvato solo nello spazio privato di questa app e viene usato esclusivamente su questo dispositivo per guidare il modello offline. Non viene mai caricato né condiviso.</string>
+    <string name="custom_words_empty">Nessuna parola personalizzata</string>
+    <string name="custom_words_add">Aggiungi parola</string>
+    <string name="custom_words_add_hint">Parola o frase</string>
+    <string name="custom_words_edit">Modifica parola</string>
+    <string name="custom_words_delete">Elimina parola</string>
+    <string name="custom_words_import">Importa elenco</string>
+    <string name="custom_words_import_hint">Una parola per riga</string>
+    <string name="custom_words_saved">Salvato</string>
+    <string name="custom_words_duplicate">Già presente nell\'elenco</string>
+    <string name="custom_words_empty_input">Inserisci una parola</string>
+    <string name="custom_words_too_long">Troppo lungo (max %1$d caratteri)</string>
+    <string name="custom_words_limit">Elenco pieno (max %1$d parole)</string>
+    <string name="custom_words_import_done">%1$d parole importate</string>
+    <string name="custom_words_import_none">Niente di nuovo da importare</string>
+    <plurals name="custom_words_count">
+        <item quantity="one">%1$d parola</item>
+        <item quantity="other">%1$d parole</item>
+    </plurals>
+
     <string name="section_benchmark">Benchmark</string>
     <string name="desc_benchmark">Misura la velocità di trascrizione del modello attivo su questo dispositivo usando una registrazione di prova in inglese integrata (11 s).</string>
     <string name="btn_benchmark">Avvia benchmark</string>
@@ -105,4 +133,55 @@
 
     <string name="voice_help_title">Configurazione dell\'immissione vocale</string>
     <string name="voice_help_body">Come usarlo\n• Apri qualsiasi app e tocca il microfono di una tastiera/app supportata. Appare un piccolo pannello, parli, tocchi per fermare e il testo viene inserito. (Attiva «Arresto automatico dopo il silenzio» nelle impostazioni per farlo fermare da solo.)\n\nQuali tastiere aprono il pannello vocale\n• Microsoft SwiftKey (non open source) e la ricerca vocale dei siti web aprono il pannello direttamente.\n• AnySoftKeyboard è la via open source al pannello: il suo tasto microfono lo apre finché nessuna tastiera vocale è attivata sul sistema.\n\nAltre tastiere open source\n• HeliBoard, FlorisBoard, OpenBoard, Fossify Keyboard e Unexpected Keyboard non aprono il pannello: il loro tasto microfono passa alla tastiera «Offline Voice Input». Attivala una volta (vedi «Alternativa: tastiera vocale»), parla lì e torna indietro con il suo tasto di cambio tastiera. FUTO Keyboard include una propria immissione vocale.\n• Gboard usa solo l\'immissione vocale di Google e non può usare affatto questa app.\n\nSe si apre l\'immissione vocale di SwiftKey\n• Impostazioni → Immissione avanzata → disattiva «Immissione vocale multimodale».\n• Poi tocca di nuovo il microfono e scegli «Offline Voice Input».\n\nSe Android chiede quale app usare\n• Scegli «Offline Voice Input» e tocca «Sempre».\n\nSe si apre sempre un\'altra app\n• Apri Impostazioni → App → quell\'app → «Apri per impostazione predefinita» → Cancella impostazioni predefinite, e riprova.</string>
+
+    <string name="section_bubble">Bolla microfono fluttuante</string>
+    <string name="desc_bubble">Mostra una bolla microfono trascinabile sullo schermo. Toccala per registrare; la trascrizione viene copiata negli appunti e salvata nella cronologia.</string>
+    <string name="bubble_enable">Mostra bolla microfono</string>
+    <string name="bubble_need_overlay">Consenti prima la visualizzazione sopra altre app.</string>
+    <string name="bubble_need_mic">Permesso microfono richiesto.</string>
+    <string name="bubble_idle">Bolla microfono – tocca per registrare</string>
+    <string name="bubble_recording">Registrazione – tocca per fermare</string>
+    <string name="bubble_processing">Elaborazione…</string>
+    <string name="bubble_copied">Copiato negli appunti</string>
+    <string name="bubble_inserted">Inserito nel campo di testo</string>
+    <string name="bubble_channel_name">Bolla microfono</string>
+    <string name="bubble_notification_title">Bolla microfono attiva</string>
+    <string name="bubble_notification_text">Tocca la bolla per registrare la voce</string>
+    <string name="bubble_stop_recording">Ferma registrazione</string>
+    <string name="bubble_hide">Nascondi bolla</string>
+
+    <string name="section_a11y">Inserimento diretto (opzionale)</string>
+    <string name="desc_a11y">Quando attivato, le trascrizioni della bolla vengono inserite direttamente nel campo di testo focalizzato tramite un servizio di accessibilità. Se l\'inserimento fallisce, il testo viene copiato negli appunti. Questo servizio scrive solo nel campo modificabile focalizzato; non legge né memorizza il contenuto dei campi e salta i campi password.</string>
+    <string name="a11y_enable">Attiva inserimento diretto</string>
+    <string name="a11y_consent_title">Permesso di accessibilità</string>
+    <string name="a11y_consent_body">L\'inserimento diretto usa un servizio di accessibilità Android per digitare il testo trascritto nel campo di testo focalizzato.\n\nCosa fa:\n• Scrive il testo trascritto nel campo modificabile visibile e focalizzato\n• Salta i campi password e sensibili\n\nCosa NON fa:\n• Leggere o memorizzare il contenuto dei campi\n• Sovrascrivere testo esistente (aggiunge al cursore)\n• Accedere a campi non focalizzati\n\nVerrai reindirizzato alle impostazioni di accessibilità per attivare il servizio.</string>
+    <string name="a11y_consent_accept">Ho capito, continua</string>
+    <string name="a11y_service_description">Inserisce la voce trascritta nel campo di testo focalizzato. Scrive solo; non legge mai il contenuto.</string>
+    <string name="a11y_not_enabled">Servizio di accessibilità non attivato. Apri le impostazioni di accessibilità per attivarlo.</string>
+
+    <string name="section_history">Cronologia trascrizioni</string>
+    <string name="history_title">Cronologia</string>
+    <string name="history_empty">Nessuna trascrizione</string>
+    <string name="history_clear_all">Cancella tutto</string>
+    <string name="history_clear_title">Cancellare la cronologia?</string>
+    <string name="history_clear_body">Tutte le trascrizioni salvate verranno eliminate definitivamente.</string>
+    <string name="history_clear_confirm">Elimina tutto</string>
+    <string name="history_copied">Copiato</string>
+    <string name="history_copy">Copia</string>
+    <string name="history_delete">Elimina</string>
+    <string name="history_meta">%1$s · %2$s</string>
+    <string name="history_source_bubble">Bolla</string>
+    <string name="history_source_popup">Pannello vocale</string>
+    <string name="history_source_ime">Tastiera vocale</string>
+    <string name="history_source_file">File audio</string>
+    <string name="btn_history">Visualizza cronologia</string>
+
+    <string name="setting_history_retention">Conservazione cronologia</string>
+    <string name="setting_history_retention_desc">Quante trascrizioni conservare. Le voci più vecchie vengono eliminate automaticamente.</string>
+    <string name="retention_off">Disattivato</string>
+    <string name="retention_10">10</string>
+    <string name="retention_25">25</string>
+    <string name="retention_50">50</string>
+    <string name="retention_100">100</string>
+    <string name="retention_unlimited">Illimitato</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -149,6 +149,19 @@
     <string name="bubble_notification_text">Toque na bolha para gravar voz</string>
     <string name="bubble_stop_recording">Parar gravação</string>
     <string name="bubble_hide">Ocultar bolha</string>
+    <string name="bubble_loading">Carregando modelo…</string>
+    <string name="bubble_load_failed">Não foi possível carregar o modelo. Tente novamente.</string>
+    <string name="bubble_unload_title">Descarregar quando ociosa</string>
+    <string name="bubble_unload_desc">Para economizar memória e bateria, descarrega o modelo quando a bolha fica ociosa por um tempo. A bolha continua visível e utilizável; a próxima gravação pode levar um momento para recarregar o modelo.</string>
+    <string name="bubble_unload_never">Nunca</string>
+    <string name="bubble_unload_5">5 min</string>
+    <string name="bubble_unload_15">15 min</string>
+    <string name="bubble_unload_30">30 min</string>
+    <string name="bubble_size_title">Tamanho da bolha</string>
+    <string name="bubble_size_desc">O tamanho da bolha flutuante na tela.</string>
+    <string name="bubble_size_small">Pequeno</string>
+    <string name="bubble_size_medium">Médio</string>
+    <string name="bubble_size_large">Grande</string>
 
     <string name="section_a11y">Inserção direta (opcional)</string>
     <string name="desc_a11y">Quando ativado, as transcrições da bolha são inseridas diretamente no campo de texto focado via serviço de acessibilidade. Se falhar, o texto é copiado para a área de transferência. Este serviço apenas escreve no campo editável focado; nunca lê ou armazena conteúdo de campos e ignora campos de senha.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -79,6 +79,34 @@
     <string name="models_threads_desc">Threads usadas na transcrição. “Automático” escolhe um valor conforme a CPU deste aparelho. Se a transcrição estiver lenta, teste outros valores; mais threads nem sempre é mais rápido.</string>
     <string name="models_threads_auto">Automático</string>
 
+    <!-- Custom words (Whisper recognition bias) -->
+    <string name="btn_custom_words">Palavras personalizadas</string>
+    <string name="custom_words_title">Palavras personalizadas</string>
+    <string name="custom_words_desc">Adicione nomes, termos técnicos ou palavras incomuns para melhorar o reconhecimento. Os modelos Whisper recebem-nas como uma dica; outros modelos ignoram-nas.</string>
+    <string name="custom_words_active_model">Modelo ativo: %1$s</string>
+    <string name="custom_words_builtin">integrado</string>
+    <string name="custom_words_not_whisper">O modelo ativo não é um modelo Whisper, por isso pode ignorar as palavras personalizadas.</string>
+    <string name="custom_words_help_title">Como funciona</string>
+    <string name="custom_words_help_body">As palavras personalizadas são passadas aos modelos Whisper como um prompt inicial, direcionando o reconhecimento para os seus nomes e termos. Não têm efeito noutros modelos.\n\nPrivacidade: a lista é armazenada apenas no armazenamento privado desta app e é usada somente neste dispositivo para orientar o modelo offline. Nunca é enviada nem partilhada.</string>
+    <string name="custom_words_empty">Ainda sem palavras personalizadas</string>
+    <string name="custom_words_add">Adicionar palavra</string>
+    <string name="custom_words_add_hint">Palavra ou frase</string>
+    <string name="custom_words_edit">Editar palavra</string>
+    <string name="custom_words_delete">Eliminar palavra</string>
+    <string name="custom_words_import">Importar lista</string>
+    <string name="custom_words_import_hint">Uma palavra por linha</string>
+    <string name="custom_words_saved">Guardado</string>
+    <string name="custom_words_duplicate">Já está na lista</string>
+    <string name="custom_words_empty_input">Introduza uma palavra</string>
+    <string name="custom_words_too_long">Muito longo (máx. %1$d caracteres)</string>
+    <string name="custom_words_limit">Lista cheia (máx. %1$d palavras)</string>
+    <string name="custom_words_import_done">%1$d palavras importadas</string>
+    <string name="custom_words_import_none">Nada de novo para importar</string>
+    <plurals name="custom_words_count">
+        <item quantity="one">%1$d palavra</item>
+        <item quantity="other">%1$d palavras</item>
+    </plurals>
+
     <string name="section_benchmark">Teste de desempenho</string>
     <string name="desc_benchmark">Mede a velocidade de transcrição do modelo ativo neste aparelho usando uma gravação de teste em inglês integrada (11 s).</string>
     <string name="btn_benchmark">Iniciar teste</string>
@@ -105,4 +133,55 @@
 
     <string name="voice_help_title">Configuração da entrada de voz</string>
     <string name="voice_help_body">Como usar\n• Abra qualquer app e toque no microfone de um teclado/app compatível. Um pequeno painel aparece, você fala, toca para parar, e o texto é inserido. (Ative «Parada automática após silêncio» nas configurações para que pare sozinho.)\n\nQuais teclados abrem o painel de voz\n• O Microsoft SwiftKey (não é de código aberto) e a busca por voz de sites abrem o painel diretamente.\n• O AnySoftKeyboard é o caminho de código aberto para o painel: sua tecla de microfone o abre desde que nenhum teclado de voz esteja ativado no sistema.\n\nOutros teclados de código aberto\n• HeliBoard, FlorisBoard, OpenBoard, Fossify Keyboard e Unexpected Keyboard não abrem o painel: a tecla de microfone deles alterna para o teclado «Offline Voice Input». Ative-o uma vez (veja «Alternativa: teclado de voz»), fale lá e volte com a tecla de troca de teclado. O FUTO Keyboard traz sua própria entrada de voz.\n• O Gboard só usa a entrada de voz do Google e não pode usar este app de forma alguma.\n\nSe a entrada de voz do próprio SwiftKey abrir\n• Configurações → Entrada avançada → desative «Entrada de voz multimodal».\n• Depois toque no microfone novamente e escolha «Offline Voice Input».\n\nSe o Android perguntar qual app usar\n• Escolha «Offline Voice Input» e toque em «Sempre».\n\nSe outro app sempre abrir\n• Abra Configurações → Apps → esse app → «Abrir por padrão» → Limpar padrões, e tente novamente.</string>
+
+    <string name="section_bubble">Bolha de microfone flutuante</string>
+    <string name="desc_bubble">Mostra uma bolha de microfone arrastável na tela. Toque para gravar; a transcrição é copiada para a área de transferência e salva no histórico.</string>
+    <string name="bubble_enable">Mostrar bolha de microfone</string>
+    <string name="bubble_need_overlay">Permita primeiro a exibição sobre outros apps.</string>
+    <string name="bubble_need_mic">Permissão de microfone necessária.</string>
+    <string name="bubble_idle">Bolha de microfone – toque para gravar</string>
+    <string name="bubble_recording">Gravando – toque para parar</string>
+    <string name="bubble_processing">Processando…</string>
+    <string name="bubble_copied">Copiado para a área de transferência</string>
+    <string name="bubble_inserted">Inserido no campo de texto</string>
+    <string name="bubble_channel_name">Bolha de microfone</string>
+    <string name="bubble_notification_title">Bolha de microfone ativa</string>
+    <string name="bubble_notification_text">Toque na bolha para gravar voz</string>
+    <string name="bubble_stop_recording">Parar gravação</string>
+    <string name="bubble_hide">Ocultar bolha</string>
+
+    <string name="section_a11y">Inserção direta (opcional)</string>
+    <string name="desc_a11y">Quando ativado, as transcrições da bolha são inseridas diretamente no campo de texto focado via serviço de acessibilidade. Se falhar, o texto é copiado para a área de transferência. Este serviço apenas escreve no campo editável focado; nunca lê ou armazena conteúdo de campos e ignora campos de senha.</string>
+    <string name="a11y_enable">Ativar inserção direta</string>
+    <string name="a11y_consent_title">Permissão de acessibilidade</string>
+    <string name="a11y_consent_body">A inserção direta usa um serviço de acessibilidade do Android para digitar o texto transcrito no campo de texto focado.\n\nO que faz:\n• Escreve o texto transcrito no campo editável visível e focado\n• Ignora campos de senha e sensíveis\n\nO que NÃO faz:\n• Ler ou armazenar conteúdo de campos\n• Sobrescrever texto existente (adiciona no cursor)\n• Acessar campos não focados\n\nVocê será redirecionado para as configurações de acessibilidade para ativar o serviço.</string>
+    <string name="a11y_consent_accept">Entendi, continuar</string>
+    <string name="a11y_service_description">Insere voz transcrita no campo de texto focado. Apenas escreve; nunca lê conteúdo.</string>
+    <string name="a11y_not_enabled">Serviço de acessibilidade não ativado. Abra as configurações de acessibilidade para ativá-lo.</string>
+
+    <string name="section_history">Histórico de transcrições</string>
+    <string name="history_title">Histórico</string>
+    <string name="history_empty">Nenhuma transcrição ainda</string>
+    <string name="history_clear_all">Limpar tudo</string>
+    <string name="history_clear_title">Limpar histórico?</string>
+    <string name="history_clear_body">Todas as transcrições salvas serão excluídas permanentemente.</string>
+    <string name="history_clear_confirm">Excluir tudo</string>
+    <string name="history_copied">Copiado</string>
+    <string name="history_copy">Copiar</string>
+    <string name="history_delete">Excluir</string>
+    <string name="history_meta">%1$s · %2$s</string>
+    <string name="history_source_bubble">Bolha</string>
+    <string name="history_source_popup">Painel de voz</string>
+    <string name="history_source_ime">Teclado de voz</string>
+    <string name="history_source_file">Arquivo de áudio</string>
+    <string name="btn_history">Ver histórico</string>
+
+    <string name="setting_history_retention">Retenção do histórico</string>
+    <string name="setting_history_retention_desc">Quantas transcrições manter. Entradas antigas são excluídas automaticamente.</string>
+    <string name="retention_off">Desativado</string>
+    <string name="retention_10">10</string>
+    <string name="retention_25">25</string>
+    <string name="retention_50">50</string>
+    <string name="retention_100">100</string>
+    <string name="retention_unlimited">Ilimitado</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -151,6 +151,19 @@
     <string name="bubble_notification_text">Нажмите на пузырь для записи речи</string>
     <string name="bubble_stop_recording">Остановить запись</string>
     <string name="bubble_hide">Скрыть пузырь</string>
+    <string name="bubble_loading">Загрузка модели…</string>
+    <string name="bubble_load_failed">Не удалось загрузить модель. Попробуйте ещё раз.</string>
+    <string name="bubble_unload_title">Выгрузка при простое</string>
+    <string name="bubble_unload_desc">Чтобы экономить память и заряд батареи, выгружать модель, когда пузырь долго простаивает. Пузырь остаётся видимым и доступным; следующая запись может потребовать немного времени на перезагрузку модели.</string>
+    <string name="bubble_unload_never">Никогда</string>
+    <string name="bubble_unload_5">5 мин</string>
+    <string name="bubble_unload_15">15 мин</string>
+    <string name="bubble_unload_30">30 мин</string>
+    <string name="bubble_size_title">Размер пузыря</string>
+    <string name="bubble_size_desc">Насколько большим отображается плавающий пузырь на экране.</string>
+    <string name="bubble_size_small">Маленький</string>
+    <string name="bubble_size_medium">Средний</string>
+    <string name="bubble_size_large">Большой</string>
 
     <string name="section_a11y">Прямая вставка (необязательно)</string>
     <string name="desc_a11y">При включении транскрипции из пузыря вставляются непосредственно в фокусированное текстовое поле через службу специальных возможностей. При неудаче текст копируется в буфер обмена. Служба только записывает в фокусированное редактируемое поле; никогда не читает и не хранит содержимое полей и пропускает поля паролей.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -79,6 +79,36 @@
     <string name="models_threads_desc">Потоки, используемые для распознавания. «Автоматически» подбирает значение под процессор этого устройства. Если распознавание медленное, попробуйте другие значения; больше потоков не всегда быстрее.</string>
     <string name="models_threads_auto">Автоматически</string>
 
+    <!-- Custom words (Whisper recognition bias) -->
+    <string name="btn_custom_words">Пользовательские слова</string>
+    <string name="custom_words_title">Пользовательские слова</string>
+    <string name="custom_words_desc">Добавляйте имена, технические термины или необычные слова, чтобы улучшить распознавание. Модели Whisper получают их как подсказку; другие модели их игнорируют.</string>
+    <string name="custom_words_active_model">Активная модель: %1$s</string>
+    <string name="custom_words_builtin">встроенная</string>
+    <string name="custom_words_not_whisper">Активная модель не является моделью Whisper, поэтому может игнорировать пользовательские слова.</string>
+    <string name="custom_words_help_title">Как это работает</string>
+    <string name="custom_words_help_body">Пользовательские слова передаются моделям Whisper как начальная подсказка, направляя распознавание на ваши имена и термины. На другие модели они не влияют.\n\nКонфиденциальность: список хранится только в закрытом хранилище приложения и используется исключительно на этом устройстве для управления офлайн-моделью. Он никогда не загружается и не передаётся.</string>
+    <string name="custom_words_empty">Пока нет пользовательских слов</string>
+    <string name="custom_words_add">Добавить слово</string>
+    <string name="custom_words_add_hint">Слово или фраза</string>
+    <string name="custom_words_edit">Изменить слово</string>
+    <string name="custom_words_delete">Удалить слово</string>
+    <string name="custom_words_import">Импортировать список</string>
+    <string name="custom_words_import_hint">По одному слову в строке</string>
+    <string name="custom_words_saved">Сохранено</string>
+    <string name="custom_words_duplicate">Уже есть в списке</string>
+    <string name="custom_words_empty_input">Введите слово</string>
+    <string name="custom_words_too_long">Слишком длинное (макс. %1$d символов)</string>
+    <string name="custom_words_limit">Список заполнен (макс. %1$d слов)</string>
+    <string name="custom_words_import_done">Импортировано слов: %1$d</string>
+    <string name="custom_words_import_none">Нечего импортировать</string>
+    <plurals name="custom_words_count">
+        <item quantity="one">%1$d слово</item>
+        <item quantity="few">%1$d слова</item>
+        <item quantity="many">%1$d слов</item>
+        <item quantity="other">%1$d слов</item>
+    </plurals>
+
     <string name="section_benchmark">Тест скорости</string>
     <string name="desc_benchmark">Измеряет скорость распознавания активной модели на этом устройстве по встроенной тестовой записи на английском (11 с).</string>
     <string name="btn_benchmark">Запустить тест</string>
@@ -105,4 +135,55 @@
 
     <string name="voice_help_title">Настройка голосового ввода</string>
     <string name="voice_help_body">Как использовать\n• Откройте любое приложение и нажмите микрофон на поддерживаемой клавиатуре/в приложении. Появится небольшая панель, вы говорите, нажимаете для остановки, и текст вставляется. (Включите «Автостоп при тишине» в настройках, чтобы она останавливалась сама.)\n\nКакие клавиатуры открывают голосовую панель\n• Microsoft SwiftKey (не с открытым кодом) и голосовой поиск на сайтах открывают панель напрямую.\n• AnySoftKeyboard — путь к панели с открытым кодом: его клавиша микрофона открывает её, пока в системе не включена ни одна голосовая клавиатура.\n\nДругие клавиатуры с открытым кодом\n• HeliBoard, FlorisBoard, OpenBoard, Fossify Keyboard и Unexpected Keyboard панель не открывают: их клавиша микрофона переключает на клавиатуру «Offline Voice Input». Включите её один раз (см. «Альтернатива: голосовая клавиатура»), говорите там и возвращайтесь клавишей переключения клавиатур. FUTO Keyboard содержит собственный голосовой ввод.\n• Gboard использует только голосовой ввод Google и вообще не может использовать это приложение.\n\nЕсли открывается собственный голосовой ввод SwiftKey\n• Настройки → Расширенный ввод → отключите «Мультимодальный голосовой ввод».\n• Затем снова нажмите микрофон и выберите «Offline Voice Input».\n\nЕсли Android спрашивает, какое приложение использовать\n• Выберите «Offline Voice Input» и нажмите «Всегда».\n\nЕсли всегда открывается другое приложение\n• Откройте Настройки → Приложения → это приложение → «Открывать по умолчанию» → Очистить настройки по умолчанию, и попробуйте снова.</string>
+
+    <string name="section_bubble">Плавающий пузырь микрофона</string>
+    <string name="desc_bubble">Показывает перетаскиваемый пузырь микрофона на экране. Нажмите для записи; транскрипция копируется в буфер обмена и сохраняется в истории.</string>
+    <string name="bubble_enable">Показать пузырь микрофона</string>
+    <string name="bubble_need_overlay">Сначала разрешите отображение поверх других приложений.</string>
+    <string name="bubble_need_mic">Требуется разрешение микрофона.</string>
+    <string name="bubble_idle">Пузырь микрофона – нажмите для записи</string>
+    <string name="bubble_recording">Запись – нажмите для остановки</string>
+    <string name="bubble_processing">Обработка…</string>
+    <string name="bubble_copied">Скопировано в буфер обмена</string>
+    <string name="bubble_inserted">Вставлено в текстовое поле</string>
+    <string name="bubble_channel_name">Пузырь микрофона</string>
+    <string name="bubble_notification_title">Пузырь микрофона активен</string>
+    <string name="bubble_notification_text">Нажмите на пузырь для записи речи</string>
+    <string name="bubble_stop_recording">Остановить запись</string>
+    <string name="bubble_hide">Скрыть пузырь</string>
+
+    <string name="section_a11y">Прямая вставка (необязательно)</string>
+    <string name="desc_a11y">При включении транскрипции из пузыря вставляются непосредственно в фокусированное текстовое поле через службу специальных возможностей. При неудаче текст копируется в буфер обмена. Служба только записывает в фокусированное редактируемое поле; никогда не читает и не хранит содержимое полей и пропускает поля паролей.</string>
+    <string name="a11y_enable">Включить прямую вставку</string>
+    <string name="a11y_consent_title">Разрешение специальных возможностей</string>
+    <string name="a11y_consent_body">Прямая вставка использует службу специальных возможностей Android для ввода транскрибированного текста в фокусированное текстовое поле.\n\nЧто она делает:\n• Записывает транскрибированный текст в видимое фокусированное редактируемое поле\n• Пропускает поля паролей и конфиденциальные поля\n\nЧего она НЕ делает:\n• Не читает и не хранит содержимое полей\n• Не перезаписывает существующий текст (добавляет у курсора)\n• Не обращается к нефокусированным полям\n\nВы будете перенаправлены в настройки специальных возможностей для включения службы.</string>
+    <string name="a11y_consent_accept">Понятно, продолжить</string>
+    <string name="a11y_service_description">Вставляет транскрибированную речь в фокусированное текстовое поле. Только записывает; никогда не читает содержимое.</string>
+    <string name="a11y_not_enabled">Служба специальных возможностей не включена. Откройте настройки специальных возможностей для включения.</string>
+
+    <string name="section_history">История транскрипций</string>
+    <string name="history_title">История</string>
+    <string name="history_empty">Транскрипций пока нет</string>
+    <string name="history_clear_all">Очистить всё</string>
+    <string name="history_clear_title">Очистить историю?</string>
+    <string name="history_clear_body">Все сохранённые транскрипции будут безвозвратно удалены.</string>
+    <string name="history_clear_confirm">Удалить всё</string>
+    <string name="history_copied">Скопировано</string>
+    <string name="history_copy">Копировать</string>
+    <string name="history_delete">Удалить</string>
+    <string name="history_meta">%1$s · %2$s</string>
+    <string name="history_source_bubble">Пузырь</string>
+    <string name="history_source_popup">Голосовая панель</string>
+    <string name="history_source_ime">Голосовая клавиатура</string>
+    <string name="history_source_file">Аудиофайл</string>
+    <string name="btn_history">Просмотр истории</string>
+
+    <string name="setting_history_retention">Хранение истории</string>
+    <string name="setting_history_retention_desc">Сколько транскрипций хранить. Старые записи удаляются автоматически.</string>
+    <string name="retention_off">Выкл</string>
+    <string name="retention_10">10</string>
+    <string name="retention_25">25</string>
+    <string name="retention_50">50</string>
+    <string name="retention_100">100</string>
+    <string name="retention_unlimited">Без ограничений</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,34 @@
     <string name="models_threads_desc">Threads used for transcription. “Automatic” picks a value based on this device\'s CPU. If transcription is slow, try different values; more threads is not always faster.</string>
     <string name="models_threads_auto">Automatic</string>
 
+    <!-- Custom words (Whisper recognition bias) -->
+    <string name="btn_custom_words">Custom words</string>
+    <string name="custom_words_title">Custom words</string>
+    <string name="custom_words_desc">Add names, technical terms, or unusual words to bias recognition. Whisper models receive them as a hint toward these words; other models ignore them.</string>
+    <string name="custom_words_active_model">Active model: %1$s</string>
+    <string name="custom_words_builtin">built-in</string>
+    <string name="custom_words_not_whisper">The active model isn\'t a Whisper model, so it may ignore custom words.</string>
+    <string name="custom_words_help_title">How it works</string>
+    <string name="custom_words_help_body">Custom words are passed to Whisper models as an initial prompt, biasing recognition toward your names and terms. They have no effect on other models.\n\nPrivacy: the list is stored only in this app\'s private storage and is used solely on this device to guide the offline model. It is never uploaded or shared.</string>
+    <string name="custom_words_empty">No custom words yet</string>
+    <string name="custom_words_add">Add word</string>
+    <string name="custom_words_add_hint">Word or phrase</string>
+    <string name="custom_words_edit">Edit word</string>
+    <string name="custom_words_delete">Delete word</string>
+    <string name="custom_words_import">Import list</string>
+    <string name="custom_words_import_hint">One word per line</string>
+    <string name="custom_words_saved">Saved</string>
+    <string name="custom_words_duplicate">Already in the list</string>
+    <string name="custom_words_empty_input">Enter a word</string>
+    <string name="custom_words_too_long">Too long (max %1$d characters)</string>
+    <string name="custom_words_limit">List is full (max %1$d words)</string>
+    <string name="custom_words_import_done">Imported %1$d words</string>
+    <string name="custom_words_import_none">Nothing new to import</string>
+    <plurals name="custom_words_count">
+        <item quantity="one">%1$d word</item>
+        <item quantity="other">%1$d words</item>
+    </plurals>
+
     <string name="section_benchmark">Benchmark</string>
     <string name="desc_benchmark">Measures how fast the active model transcribes on this device, using a built-in English test recording (11 s).</string>
     <string name="btn_benchmark">Run benchmark</string>
@@ -110,5 +138,61 @@
     <string name="voice_test_failed">Couldn\'t start voice input on this device.</string>
 
     <string name="voice_help_title">Voice input setup</string>
-    <string name="voice_help_body">How to use it\n• Open any app and tap the microphone on a supported keyboard/app. A small panel slides up, you speak, tap to stop, and the text is inserted. (Enable “Auto-stop after silence” in the settings to have it stop by itself.)\n\nWhich keyboards open the voice panel\n• Microsoft SwiftKey (not open source) and website voice search open the panel directly.\n• AnySoftKeyboard is the open-source way to get the panel: its mic key opens it as long as no voice keyboard is enabled on your system.\n\nOther open-source keyboards\n• HeliBoard, FlorisBoard, OpenBoard, Fossify Keyboard and Unexpected Keyboard don\'t open the panel: their mic key switches to the “Offline Voice Input” keyboard instead. Enable it once (see “Alternative: Voice keyboard”), speak there, and use its keyboard-switch key to go back. FUTO Keyboard ships its own voice input.\n• Gboard only uses Google\'s own voice typing and can\'t use this app at all.\n\nIf SwiftKey\'s own voice typing opens instead\n• Settings → Rich input → turn off “Multi-modal voice typing”.\n• Then tap the mic again and pick “Offline Voice Input”.\n\nIf Android asks which app to use\n• Choose “Offline Voice Input” and tap “Always”.\n\nIf another app always opens instead\n• Open Settings → Apps → that app → “Open by default” → Clear defaults, then try again.</string>
+    <string name="voice_help_body">How to use it\n• Open any app and tap the microphone on a supported keyboard/app. A small panel slides up, you speak, tap to stop, and the text is inserted. (Enable "Auto-stop after silence" in the settings to have it stop by itself.)\n\nWhich keyboards open the voice panel\n• Microsoft SwiftKey (not open source) and website voice search open the panel directly.\n• AnySoftKeyboard is the open-source way to get the panel: its mic key opens it as long as no voice keyboard is enabled on your system.\n\nOther open-source keyboards\n• HeliBoard, FlorisBoard, OpenBoard, Fossify Keyboard and Unexpected Keyboard don\'t open the panel: their mic key switches to the "Offline Voice Input" keyboard instead. Enable it once (see "Alternative: Voice keyboard"), speak there, and use its keyboard-switch key to go back. FUTO Keyboard ships its own voice input.\n• Gboard only uses Google\'s own voice typing and can\'t use this app at all.\n\nIf SwiftKey\'s own voice typing opens instead\n• Settings → Rich input → turn off "Multi-modal voice typing".\n• Then tap the mic again and pick "Offline Voice Input".\n\nIf Android asks which app to use\n• Choose "Offline Voice Input" and tap "Always".\n\nIf another app always opens instead\n• Open Settings → Apps → that app → "Open by default" → Clear defaults, then try again.</string>
+
+    <!-- Floating mic bubble -->
+    <string name="section_bubble">Floating mic bubble</string>
+    <string name="desc_bubble">Show a draggable microphone bubble on screen. Tap it to record; the transcription is copied to your clipboard and saved to history.</string>
+    <string name="bubble_enable">Show mic bubble</string>
+    <string name="bubble_need_overlay">Please allow display over other apps first.</string>
+    <string name="bubble_need_mic">Microphone permission required.</string>
+    <string name="bubble_idle">Mic bubble – tap to record</string>
+    <string name="bubble_recording">Recording – tap to stop</string>
+    <string name="bubble_processing">Processing…</string>
+    <string name="bubble_copied">Copied to clipboard</string>
+    <string name="bubble_inserted">Inserted into text field</string>
+    <string name="bubble_channel_name">Mic bubble</string>
+    <string name="bubble_notification_title">Mic bubble active</string>
+    <string name="bubble_notification_text">Tap the bubble to record speech</string>
+    <string name="bubble_stop_recording">Stop recording</string>
+    <string name="bubble_hide">Hide bubble</string>
+
+    <!-- Accessibility direct insertion -->
+    <string name="section_a11y">Direct text insertion (optional)</string>
+    <string name="desc_a11y">When enabled, transcriptions from the mic bubble are inserted directly into the focused text field via an accessibility service. If insertion fails, the text is copied to your clipboard instead. This service only writes to the focused editable field; it never reads or stores field content, and skips password fields.</string>
+    <string name="a11y_enable">Enable direct insertion</string>
+    <string name="a11y_consent_title">Accessibility permission</string>
+    <string name="a11y_consent_body">Direct insertion uses an Android accessibility service to type transcribed text into the focused text field.\n\nWhat it does:\n• Writes transcribed text to the currently focused, visible editable field\n• Skips password and sensitive fields\n\nWhat it does NOT do:\n• Read or store any field content\n• Overwrite existing text (it appends at the cursor)\n• Access fields that are not focused\n\nYou will be taken to Accessibility Settings to enable the service.</string>
+    <string name="a11y_consent_accept">I understand, continue</string>
+    <string name="a11y_service_description">Inserts transcribed speech into the focused text field. Only writes text; never reads field content.</string>
+    <string name="a11y_not_enabled">Accessibility service not enabled. Open Accessibility Settings to turn it on.</string>
+
+    <!-- Transcription history -->
+    <string name="section_history">Transcription history</string>
+    <string name="history_title">History</string>
+    <string name="history_empty">No transcriptions yet</string>
+    <string name="history_clear_all">Clear all</string>
+    <string name="history_clear_title">Clear history?</string>
+    <string name="history_clear_body">All saved transcriptions will be permanently deleted.</string>
+    <string name="history_clear_confirm">Delete all</string>
+    <string name="history_copied">Copied</string>
+    <string name="history_copy">Copy</string>
+    <string name="history_delete">Delete</string>
+    <string name="history_meta">%1$s · %2$s</string>
+    <string name="history_source_bubble">Bubble</string>
+    <string name="history_source_popup">Voice popup</string>
+    <string name="history_source_ime">Voice keyboard</string>
+    <string name="history_source_file">Audio file</string>
+    <string name="history_source_service">Speech service</string>
+    <string name="btn_history">View history</string>
+
+    <!-- History retention -->
+    <string name="setting_history_retention">History retention</string>
+    <string name="setting_history_retention_desc">How many transcriptions to keep. Older entries are deleted automatically.</string>
+    <string name="retention_off">Off</string>
+    <string name="retention_10">10</string>
+    <string name="retention_25">25</string>
+    <string name="retention_50">50</string>
+    <string name="retention_100">100</string>
+    <string name="retention_unlimited">Unlimited</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,6 +156,19 @@
     <string name="bubble_notification_text">Tap the bubble to record speech</string>
     <string name="bubble_stop_recording">Stop recording</string>
     <string name="bubble_hide">Hide bubble</string>
+    <string name="bubble_loading">Loading model…</string>
+    <string name="bubble_load_failed">Couldn\'t load the model. Please try again.</string>
+    <string name="bubble_unload_title">Unload when idle</string>
+    <string name="bubble_unload_desc">To save memory and battery, unload the model once the bubble has sat idle for a while. The bubble stays visible and usable; the next recording may take a moment to reload the model.</string>
+    <string name="bubble_unload_never">Never</string>
+    <string name="bubble_unload_5">5 min</string>
+    <string name="bubble_unload_15">15 min</string>
+    <string name="bubble_unload_30">30 min</string>
+    <string name="bubble_size_title">Bubble size</string>
+    <string name="bubble_size_desc">How large the floating bubble appears on screen.</string>
+    <string name="bubble_size_small">Small</string>
+    <string name="bubble_size_medium">Medium</string>
+    <string name="bubble_size_large">Large</string>
 
     <!-- Accessibility direct insertion -->
     <string name="section_a11y">Direct text insertion (optional)</string>

--- a/app/src/main/res/xml/accessibility_insertion.xml
+++ b/app/src/main/res/xml/accessibility_insertion.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeViewFocused"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagDefault"
+    android:canRetrieveWindowContent="true"
+    android:description="@string/a11y_service_description"
+    android:notificationTimeout="100" />

--- a/app/src/test/java/dev/notune/transcribe/BubblePrefsTest.java
+++ b/app/src/test/java/dev/notune/transcribe/BubblePrefsTest.java
@@ -1,0 +1,130 @@
+package dev.notune.transcribe;
+
+import static org.junit.Assert.assertEquals;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.File;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class BubblePrefsTest {
+
+    private Context ctx;
+
+    @Before
+    public void setUp() {
+        ctx = ApplicationProvider.getApplicationContext();
+        new File(ctx.getFilesDir(), "bubble_unload_minutes").delete();
+        new File(ctx.getFilesDir(), "bubble_size_dp").delete();
+    }
+
+    // --- Defaults for new users --------------------------------------------
+
+    @Test
+    public void unloadDefaultsToFifteenMinutes() {
+        assertEquals(15, BubblePrefs.getUnloadMinutes(ctx));
+        assertEquals(15, BubblePrefs.DEFAULT_UNLOAD_MINUTES);
+    }
+
+    @Test
+    public void sizeDefaultsToMedium() {
+        assertEquals(56, BubblePrefs.getSizeDp(ctx));
+        assertEquals(56, BubblePrefs.DEFAULT_SIZE_DP);
+    }
+
+    // --- Unload interval normalization -------------------------------------
+
+    @Test
+    public void unloadNormalizesToOfferedChoices() {
+        assertEquals(0, BubblePrefs.normalizeUnloadMinutes(0));
+        assertEquals(5, BubblePrefs.normalizeUnloadMinutes(5));
+        assertEquals(15, BubblePrefs.normalizeUnloadMinutes(15));
+        assertEquals(30, BubblePrefs.normalizeUnloadMinutes(30));
+    }
+
+    @Test
+    public void unloadSnapsNearestChoice() {
+        assertEquals(0, BubblePrefs.normalizeUnloadMinutes(1));
+        assertEquals(5, BubblePrefs.normalizeUnloadMinutes(4));
+        assertEquals(15, BubblePrefs.normalizeUnloadMinutes(12));
+        assertEquals(30, BubblePrefs.normalizeUnloadMinutes(29));
+        assertEquals(30, BubblePrefs.normalizeUnloadMinutes(1000));
+    }
+
+    @Test
+    public void unloadSetGetRoundTrip() {
+        BubblePrefs.setUnloadMinutes(ctx, 30);
+        assertEquals(30, BubblePrefs.getUnloadMinutes(ctx));
+        BubblePrefs.setUnloadMinutes(ctx, 0);
+        assertEquals(0, BubblePrefs.getUnloadMinutes(ctx));
+    }
+
+    @Test
+    public void unloadSetNormalizesInvalidValue() {
+        BubblePrefs.setUnloadMinutes(ctx, 99);
+        assertEquals(30, BubblePrefs.getUnloadMinutes(ctx));
+    }
+
+    // --- Size normalization ------------------------------------------------
+
+    @Test
+    public void sizeNormalizesToOfferedChoices() {
+        assertEquals(48, BubblePrefs.normalizeSizeDp(48));
+        assertEquals(56, BubblePrefs.normalizeSizeDp(56));
+        assertEquals(72, BubblePrefs.normalizeSizeDp(72));
+    }
+
+    @Test
+    public void sizeSnapsNearestChoice() {
+        assertEquals(48, BubblePrefs.normalizeSizeDp(50));
+        assertEquals(56, BubblePrefs.normalizeSizeDp(60));
+        assertEquals(72, BubblePrefs.normalizeSizeDp(70));
+        assertEquals(72, BubblePrefs.normalizeSizeDp(1000));
+    }
+
+    @Test
+    public void sizeNeverBelowMinimumTouchTarget() {
+        assertEquals(BubblePrefs.MIN_SIZE_DP, BubblePrefs.normalizeSizeDp(0));
+        assertEquals(BubblePrefs.MIN_SIZE_DP, BubblePrefs.normalizeSizeDp(-20));
+        assertEquals(48, BubblePrefs.MIN_SIZE_DP);
+    }
+
+    @Test
+    public void sizeSetGetRoundTrip() {
+        BubblePrefs.setSizeDp(ctx, 72);
+        assertEquals(72, BubblePrefs.getSizeDp(ctx));
+        BubblePrefs.setSizeDp(ctx, 48);
+        assertEquals(48, BubblePrefs.getSizeDp(ctx));
+    }
+
+    @Test
+    public void sizeSetNormalizesInvalidValue() {
+        BubblePrefs.setSizeDp(ctx, 10);
+        assertEquals(48, BubblePrefs.getSizeDp(ctx));
+    }
+
+    // --- Position persistence (existing behavior, kept) --------------------
+
+    @Test
+    public void positionDefaultsToAbsent() {
+        assertEquals(-1, BubblePrefs.getX(ctx));
+        assertEquals(-1, BubblePrefs.getY(ctx));
+    }
+
+    @Test
+    public void positionRoundTrip() {
+        BubblePrefs.setX(ctx, 120);
+        BubblePrefs.setY(ctx, 340);
+        assertEquals(120, BubblePrefs.getX(ctx));
+        assertEquals(340, BubblePrefs.getY(ctx));
+    }
+}

--- a/app/src/test/java/dev/notune/transcribe/CustomWordsPrefsTest.java
+++ b/app/src/test/java/dev/notune/transcribe/CustomWordsPrefsTest.java
@@ -1,0 +1,182 @@
+package dev.notune.transcribe;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.File;
+import java.util.List;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class CustomWordsPrefsTest {
+
+    private Context ctx;
+
+    @Before
+    public void setUp() {
+        ctx = ApplicationProvider.getApplicationContext();
+        new File(ctx.getFilesDir(), "custom_words").delete();
+    }
+
+    @Test
+    public void normalizeTrimsAndCollapses() {
+        assertEquals("hello world", CustomWordsPrefs.normalize("  hello   world  "));
+        assertEquals("a b c", CustomWordsPrefs.normalize("a\tb\nc"));
+        assertNull(CustomWordsPrefs.normalize(null));
+        assertNull(CustomWordsPrefs.normalize(""));
+        assertNull(CustomWordsPrefs.normalize("   "));
+    }
+
+    @Test
+    public void addAndGet() {
+        assertEquals(CustomWordsPrefs.AddResult.ADDED, CustomWordsPrefs.add(ctx, "Kubernetes"));
+        List<String> all = CustomWordsPrefs.getAll(ctx);
+        assertEquals(1, all.size());
+        assertEquals("Kubernetes", all.get(0));
+    }
+
+    @Test
+    public void addEmptyRejected() {
+        assertEquals(CustomWordsPrefs.AddResult.EMPTY, CustomWordsPrefs.add(ctx, ""));
+        assertEquals(CustomWordsPrefs.AddResult.EMPTY, CustomWordsPrefs.add(ctx, "   "));
+        assertEquals(CustomWordsPrefs.AddResult.EMPTY, CustomWordsPrefs.add(ctx, null));
+        assertTrue(CustomWordsPrefs.getAll(ctx).isEmpty());
+    }
+
+    @Test
+    public void addTooLongRejected() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < CustomWordsPrefs.MAX_ENTRY_LENGTH + 1; i++) sb.append('x');
+        assertEquals(CustomWordsPrefs.AddResult.TOO_LONG, CustomWordsPrefs.add(ctx, sb.toString()));
+        assertTrue(CustomWordsPrefs.getAll(ctx).isEmpty());
+    }
+
+    @Test
+    public void addExactlyMaxLengthAllowed() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < CustomWordsPrefs.MAX_ENTRY_LENGTH; i++) sb.append('x');
+        assertEquals(CustomWordsPrefs.AddResult.ADDED, CustomWordsPrefs.add(ctx, sb.toString()));
+        assertEquals(1, CustomWordsPrefs.getAll(ctx).size());
+    }
+
+    @Test
+    public void duplicateIsCaseInsensitiveAndKeepsFirstSpelling() {
+        CustomWordsPrefs.add(ctx, "Kubernetes");
+        assertEquals(CustomWordsPrefs.AddResult.DUPLICATE, CustomWordsPrefs.add(ctx, "kubernetes"));
+        assertEquals(CustomWordsPrefs.AddResult.DUPLICATE, CustomWordsPrefs.add(ctx, "KUBERNETES "));
+        List<String> all = CustomWordsPrefs.getAll(ctx);
+        assertEquals(1, all.size());
+        assertEquals("Kubernetes", all.get(0));
+    }
+
+    @Test
+    public void orderIsPreserved() {
+        CustomWordsPrefs.add(ctx, "alpha");
+        CustomWordsPrefs.add(ctx, "beta");
+        CustomWordsPrefs.add(ctx, "gamma");
+        List<String> all = CustomWordsPrefs.getAll(ctx);
+        assertEquals(3, all.size());
+        assertEquals("alpha", all.get(0));
+        assertEquals("beta", all.get(1));
+        assertEquals("gamma", all.get(2));
+    }
+
+    @Test
+    public void limitReached() {
+        for (int i = 0; i < CustomWordsPrefs.MAX_WORDS; i++) {
+            assertEquals(CustomWordsPrefs.AddResult.ADDED,
+                    CustomWordsPrefs.add(ctx, "word" + i));
+        }
+        assertEquals(CustomWordsPrefs.AddResult.LIMIT_REACHED,
+                CustomWordsPrefs.add(ctx, "overflow"));
+        assertEquals(CustomWordsPrefs.MAX_WORDS, CustomWordsPrefs.getAll(ctx).size());
+    }
+
+    @Test
+    public void removeIsCaseInsensitive() {
+        CustomWordsPrefs.add(ctx, "Schopenhauer");
+        CustomWordsPrefs.add(ctx, "Nietzsche");
+        CustomWordsPrefs.remove(ctx, "schopenhauer");
+        List<String> all = CustomWordsPrefs.getAll(ctx);
+        assertEquals(1, all.size());
+        assertEquals("Nietzsche", all.get(0));
+    }
+
+    @Test
+    public void updateKeepsPosition() {
+        CustomWordsPrefs.add(ctx, "one");
+        CustomWordsPrefs.add(ctx, "two");
+        CustomWordsPrefs.add(ctx, "three");
+        assertEquals(CustomWordsPrefs.AddResult.ADDED, CustomWordsPrefs.update(ctx, "two", "TWO"));
+        List<String> all = CustomWordsPrefs.getAll(ctx);
+        assertEquals(3, all.size());
+        assertEquals("TWO", all.get(1));
+    }
+
+    @Test
+    public void updateToExistingDuplicateRejected() {
+        CustomWordsPrefs.add(ctx, "one");
+        CustomWordsPrefs.add(ctx, "two");
+        assertEquals(CustomWordsPrefs.AddResult.DUPLICATE,
+                CustomWordsPrefs.update(ctx, "two", "ONE"));
+        assertEquals("two", CustomWordsPrefs.getAll(ctx).get(1));
+    }
+
+    @Test
+    public void updateMissingEntryIsEmpty() {
+        CustomWordsPrefs.add(ctx, "one");
+        assertEquals(CustomWordsPrefs.AddResult.EMPTY,
+                CustomWordsPrefs.update(ctx, "ghost", "replacement"));
+    }
+
+    @Test
+    public void importBulkOnePerLineSkipsBlanksAndDupes() {
+        CustomWordsPrefs.add(ctx, "alpha");
+        String text = "beta\n\n  gamma  \nALPHA\ndelta\n";
+        int added = CustomWordsPrefs.importBulk(ctx, text);
+        assertEquals(3, added);
+        List<String> all = CustomWordsPrefs.getAll(ctx);
+        assertEquals(4, all.size());
+        assertEquals("alpha", all.get(0));
+        assertEquals("beta", all.get(1));
+        assertEquals("gamma", all.get(2));
+        assertEquals("delta", all.get(3));
+    }
+
+    @Test
+    public void importBulkRespectsLimit() {
+        for (int i = 0; i < CustomWordsPrefs.MAX_WORDS - 2; i++) {
+            CustomWordsPrefs.add(ctx, "word" + i);
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 10; i++) sb.append("new").append(i).append('\n');
+        int added = CustomWordsPrefs.importBulk(ctx, sb.toString());
+        assertEquals(2, added);
+        assertEquals(CustomWordsPrefs.MAX_WORDS, CustomWordsPrefs.getAll(ctx).size());
+    }
+
+    @Test
+    public void importBulkNullReturnsZero() {
+        assertEquals(0, CustomWordsPrefs.importBulk(ctx, null));
+    }
+
+    @Test
+    public void persistsAcrossReads() {
+        CustomWordsPrefs.add(ctx, "persisted");
+        // A fresh read from disk sees the same data.
+        assertEquals("persisted", CustomWordsPrefs.getAll(ctx).get(0));
+        CustomWordsPrefs.remove(ctx, "persisted");
+        assertTrue(CustomWordsPrefs.getAll(ctx).isEmpty());
+    }
+}

--- a/app/src/test/java/dev/notune/transcribe/TranscriptionHistoryTest.java
+++ b/app/src/test/java/dev/notune/transcribe/TranscriptionHistoryTest.java
@@ -1,0 +1,124 @@
+package dev.notune.transcribe;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.List;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class TranscriptionHistoryTest {
+
+    private Context ctx;
+    private TranscriptionHistory db;
+
+    @Before
+    public void setUp() {
+        ctx = ApplicationProvider.getApplicationContext();
+        TranscriptionHistory.resetForTesting();
+        db = TranscriptionHistory.get(ctx);
+        db.clearAll();
+        HistoryPrefs.setRetention(ctx, HistoryPrefs.DEFAULT_RETENTION);
+    }
+
+    @After
+    public void tearDown() {
+        db.clearAll();
+        HistoryPrefs.setRetention(ctx, HistoryPrefs.DEFAULT_RETENTION);
+        TranscriptionHistory.resetForTesting();
+    }
+
+    @Test
+    public void insertAndQuery() {
+        db.insert("hello world", TranscriptionHistory.SOURCE_BUBBLE);
+        List<TranscriptionHistory.Entry> entries = db.query(0);
+        assertEquals(1, entries.size());
+        assertEquals("hello world", entries.get(0).text);
+        assertEquals(TranscriptionHistory.SOURCE_BUBBLE, entries.get(0).source);
+        assertTrue(entries.get(0).timestamp > 0);
+    }
+
+    @Test
+    public void insertEmptyIgnored() {
+        db.insert("", TranscriptionHistory.SOURCE_BUBBLE);
+        db.insert("   ", TranscriptionHistory.SOURCE_BUBBLE);
+        db.insert(null, TranscriptionHistory.SOURCE_BUBBLE);
+        assertEquals(0, db.query(0).size());
+    }
+
+    @Test
+    public void newestFirst() throws InterruptedException {
+        db.insert("first", TranscriptionHistory.SOURCE_POPUP);
+        Thread.sleep(10);
+        db.insert("second", TranscriptionHistory.SOURCE_IME);
+        List<TranscriptionHistory.Entry> entries = db.query(0);
+        assertEquals(2, entries.size());
+        assertEquals("second", entries.get(0).text);
+        assertEquals("first", entries.get(1).text);
+    }
+
+    @Test
+    public void deleteEntry() {
+        db.insert("to delete", TranscriptionHistory.SOURCE_FILE);
+        List<TranscriptionHistory.Entry> entries = db.query(0);
+        assertEquals(1, entries.size());
+        db.delete(entries.get(0).id);
+        assertEquals(0, db.query(0).size());
+    }
+
+    @Test
+    public void clearAll() {
+        db.insert("one", TranscriptionHistory.SOURCE_BUBBLE);
+        db.insert("two", TranscriptionHistory.SOURCE_POPUP);
+        db.clearAll();
+        assertEquals(0, db.query(0).size());
+    }
+
+    @Test
+    public void pruneRespectsRetention() {
+        HistoryPrefs.setRetention(ctx, 3);
+        for (int i = 0; i < 10; i++) {
+            db.insert("entry " + i, TranscriptionHistory.SOURCE_BUBBLE);
+        }
+        List<TranscriptionHistory.Entry> entries = db.query(0);
+        assertTrue(entries.size() <= 3);
+        HistoryPrefs.setRetention(ctx, HistoryPrefs.DEFAULT_RETENTION);
+    }
+
+    @Test
+    public void pruneDisabledWhenOff() {
+        HistoryPrefs.setRetention(ctx, 0);
+        for (int i = 0; i < 30; i++) {
+            db.insert("entry " + i, TranscriptionHistory.SOURCE_BUBBLE);
+        }
+        assertEquals(0, db.query(0).size());
+    }
+
+    @Test
+    public void unlimitedRetentionKeepsAll() {
+        HistoryPrefs.setRetention(ctx, -1);
+        for (int i = 0; i < 30; i++) {
+            db.insert("entry " + i, TranscriptionHistory.SOURCE_BUBBLE);
+        }
+        assertEquals(30, db.query(0).size());
+    }
+
+    @Test
+    public void queryWithLimit() {
+        for (int i = 0; i < 10; i++) {
+            db.insert("entry " + i, TranscriptionHistory.SOURCE_BUBBLE);
+        }
+        assertEquals(5, db.query(5).size());
+    }
+}

--- a/src/bubble.rs
+++ b/src/bubble.rs
@@ -1,0 +1,48 @@
+use jni::objects::{JClass, JObject};
+use jni::JNIEnv;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+use crate::voice_session::{self, VoiceSessionState};
+
+static BUBBLE_STATE: Lazy<Mutex<Option<VoiceSessionState>>> = Lazy::new(|| Mutex::new(None));
+
+#[no_mangle]
+pub unsafe extern "system" fn Java_dev_notune_transcribe_BubbleService_initNative(
+    env: JNIEnv,
+    _class: JClass,
+    service: JObject,
+) {
+    let state = voice_session::init_session(env, service);
+    *BUBBLE_STATE.lock().unwrap() = Some(state);
+}
+
+#[no_mangle]
+pub unsafe extern "system" fn Java_dev_notune_transcribe_BubbleService_cleanupNative(
+    _env: JNIEnv,
+    _class: JClass,
+) {
+    *BUBBLE_STATE.lock().unwrap() = None;
+}
+
+#[no_mangle]
+pub unsafe extern "system" fn Java_dev_notune_transcribe_BubbleService_startRecordingNative(
+    env: JNIEnv,
+    _class: JClass,
+) {
+    let mut guard = BUBBLE_STATE.lock().unwrap();
+    if let Some(state) = guard.as_mut() {
+        voice_session::start_recording(env, state, false);
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "system" fn Java_dev_notune_transcribe_BubbleService_stopRecordingNative(
+    env: JNIEnv,
+    _class: JClass,
+) {
+    let mut guard = BUBBLE_STATE.lock().unwrap();
+    if let Some(state) = guard.as_mut() {
+        voice_session::stop_recording(env, state);
+    }
+}

--- a/src/bubble.rs
+++ b/src/bubble.rs
@@ -1,8 +1,10 @@
 use jni::objects::{JClass, JObject};
+use jni::sys::jboolean;
 use jni::JNIEnv;
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
 
+use crate::engine;
 use crate::voice_session::{self, VoiceSessionState};
 
 static BUBBLE_STATE: Lazy<Mutex<Option<VoiceSessionState>>> = Lazy::new(|| Mutex::new(None));
@@ -44,5 +46,43 @@ pub unsafe extern "system" fn Java_dev_notune_transcribe_BubbleService_stopRecor
     let mut guard = BUBBLE_STATE.lock().unwrap();
     if let Some(state) = guard.as_mut() {
         voice_session::stop_recording(env, state);
+    }
+}
+
+/// Battery-saver unload: frees the shared model only when no component holds a
+/// reference (see `engine::unload_if_idle`). The bubble's own session
+/// (`BUBBLE_STATE`) is kept — only the heavy model is dropped, so the overlay
+/// stays live and the next tap reloads. Returns whether the model was unloaded
+/// (or already absent); `false` means another transcription is in flight and
+/// the caller should retry later.
+#[no_mangle]
+pub unsafe extern "system" fn Java_dev_notune_transcribe_BubbleService_unloadNative(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jboolean {
+    engine::unload_if_idle() as jboolean
+}
+
+/// Reloads the shared engine on a caller-owned background thread, blocking
+/// until it is ready or fails. Clones the session's JVM/target refs out of
+/// `BUBBLE_STATE` and releases the lock before loading so a slow load never
+/// blocks recording start/stop. Returns `false` when there is no session
+/// (never start a recording then) or the load failed.
+#[no_mangle]
+pub unsafe extern "system" fn Java_dev_notune_transcribe_BubbleService_ensureEngineNative(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jboolean {
+    let parts = {
+        let guard = BUBBLE_STATE.lock().unwrap();
+        guard
+            .as_ref()
+            .map(|state| (state.jvm.clone(), state.target_ref.clone()))
+    };
+    match parts {
+        Some((jvm, target_ref)) => {
+            engine::ensure_loaded_from_thread(&jvm, &target_ref).is_ok() as jboolean
+        }
+        None => 0 as jboolean,
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -274,6 +274,44 @@ pub fn reset() {
     *state = LoadState::Idle;
 }
 
+/// Drops the shared engine to free model memory, but only when it is safe:
+/// no component may currently hold a reference. Every transcription runs on
+/// its own `Arc` clone obtained from [`get_engine`] (see `transcribe_shared`
+/// callers), so a strong count of 1 means the global slot is the sole owner
+/// and dropping it actually releases the model. If another thread holds a
+/// clone — an in-flight bubble/file/recognition/subtitle transcription — the
+/// count is > 1 and this returns `false` without touching the engine, so an
+/// active user is never interrupted.
+///
+/// Returns `true` when the engine is unloaded (or was already absent) and
+/// `false` when another user currently holds it. Lock ordering matches
+/// [`reset`]/[`ensure_loaded_from_thread`] (load state before engine) to avoid
+/// a deadlock. The voice IME runs in a separate `:ime` process with its own
+/// engine singleton, so it is unaffected by an unload here.
+pub fn unload_if_idle() -> bool {
+    let (lock, cvar) = &*LOAD_STATE;
+    let mut state = lock.lock().unwrap();
+    // Settle any in-flight load first so we don't clear the slot only for the
+    // loader to repopulate it immediately after.
+    while *state == LoadState::Loading {
+        state = cvar.wait(state).unwrap();
+    }
+    let mut engine = GLOBAL_ENGINE.lock().unwrap();
+    match engine.as_ref() {
+        None => true,
+        Some(arc) => {
+            if Arc::strong_count(arc) > 1 {
+                // A transcription thread holds a clone — not safe to drop.
+                return false;
+            }
+            *engine = None;
+            *state = LoadState::Idle;
+            cvar.notify_all();
+            true
+        }
+    }
+}
+
 fn notify_status(env: &mut JNIEnv, obj: &JObject, msg: &str) {
     if let Ok(jmsg) = env.new_string(msg) {
         let _ = env.call_method(

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -29,6 +29,11 @@ const MODEL_TRANSLATE_FILE: &str = "model_translate";
 /// Optional file in filesDir with the CPU thread count for inference.
 /// Absent/invalid/0 = default (all cores).
 const MODEL_THREADS_FILE: &str = "model_threads";
+/// Optional file in filesDir with the user's custom words, one per line
+/// (written by `CustomWordsPrefs`). Whisper models receive them as the
+/// initial prompt — a recognition bias toward these words; models without
+/// the whisper run extension ignore them.
+const MODEL_CUSTOM_WORDS_FILE: &str = "custom_words";
 
 /// Longest audio passed to the model in one run (60 s). Offline conformer
 /// models use full self-attention, whose cost grows quadratically with input
@@ -58,6 +63,7 @@ impl Engine {
         language: Option<String>,
         translate: bool,
         threads: i32,
+        custom_words: Vec<String>,
     ) -> Result<Engine, String> {
         if !model_path.is_file() {
             return Err(format!("model file not found: {}", model_path.display()));
@@ -92,6 +98,16 @@ impl Engine {
         // pass is the better trade: worst case is a worse line of text, not
         // a multiplied wait. temperature_inc = 0 turns the retry ladder off;
         // models that don't take the whisper run extension are unaffected.
+        // Custom words become Whisper's initial prompt, a recognition bias
+        // toward the user's names/terms. This is the only place they enter the
+        // model: the run extension is built solely for models that accept the
+        // whisper run extension, so non-Whisper models get no substitution and
+        // simply keep transcribing as before.
+        let initial_prompt = if custom_words.is_empty() {
+            None
+        } else {
+            Some(custom_words.join(", "))
+        };
         let run_ext = if model.accepts_ext(
             transcribe_cpp::ExtSlot::Run,
             transcribe_cpp::sys::TRANSCRIBE_EXT_KIND_WHISPER_RUN,
@@ -99,6 +115,7 @@ impl Engine {
             Some(transcribe_cpp::RunExtension::Whisper(
                 transcribe_cpp::WhisperRunOptions {
                     temperature_inc: Some(0.0),
+                    initial_prompt,
                     ..Default::default()
                 },
             ))
@@ -107,10 +124,11 @@ impl Engine {
         };
 
         log::info!(
-            "engine: {} threads, task {:?}, single-pass decode: {}",
+            "engine: {} threads, task {:?}, single-pass decode: {}, custom words: {}",
             threads,
             task,
-            run_ext.is_some()
+            run_ext.is_some(),
+            custom_words.len()
         );
         let options = transcribe_cpp::SessionOptions {
             n_threads: threads,
@@ -435,6 +453,22 @@ fn read_config(path: &Path) -> Option<String> {
     }
 }
 
+/// Reads the custom-word list (one entry per line) written by `CustomWordsPrefs`.
+/// Lines are trimmed and blanks dropped; the Java side is the authority for
+/// normalization, casing, ordering and dedup, so this only guards against stray
+/// empty lines. Absent file = no custom words.
+fn read_custom_words(path: &Path) -> Vec<String> {
+    match std::fs::read_to_string(path) {
+        Ok(s) => s
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty())
+            .map(String::from)
+            .collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
 /// Performs the model load: the selected imported GGUF if any (falling back
 /// to the bundled model on failure), otherwise the bundled model.
 fn do_load(env: &mut JNIEnv, context: &JObject) -> Result<(), String> {
@@ -457,11 +491,12 @@ fn do_load(env: &mut JNIEnv, context: &JObject) -> Result<(), String> {
         .and_then(|s| s.parse::<i32>().ok())
         .filter(|&n| n > 0)
         .unwrap_or_else(performance_core_count);
+    let custom_words = read_custom_words(&files_dir.join(MODEL_CUSTOM_WORDS_FILE));
 
     if let Some(name) = read_config(&files_dir.join(ACTIVE_MODEL_FILE)) {
         let path = files_dir.join("models").join(&name);
         notify_status(env, context, &format!("Loading model {}...", name));
-        match Engine::load(&path, language.clone(), translate, threads) {
+        match Engine::load(&path, language.clone(), translate, threads, custom_words.clone()) {
             Ok(engine) => {
                 let status = engine.ready_status;
                 *GLOBAL_ENGINE.lock().unwrap() = Some(Arc::new(Mutex::new(engine)));
@@ -490,7 +525,7 @@ fn do_load(env: &mut JNIEnv, context: &JObject) -> Result<(), String> {
 
     notify_status(env, context, "Loading model...");
 
-    match Engine::load(&path, language, translate, threads) {
+    match Engine::load(&path, language, translate, threads, custom_words) {
         Ok(engine) => {
             let status = engine.ready_status;
             *GLOBAL_ENGINE.lock().unwrap() = Some(Arc::new(Mutex::new(engine)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod assets;
 pub mod audio;
+pub mod bubble;
 pub mod engine;
 pub mod ime;
 pub mod main_activity;

--- a/src/models.rs
+++ b/src/models.rs
@@ -3,15 +3,11 @@ use jni::objects::{JClass, JObject};
 use jni::JNIEnv;
 use std::sync::Arc;
 
-/// Called after the user changes the model selection (or language hint):
-/// drops the current engine and reloads with the new selection, reporting
-/// progress via the activity's `onStatusUpdate` callback.
-#[no_mangle]
-pub unsafe extern "system" fn Java_dev_notune_transcribe_ModelsActivity_reloadModelNative(
-    env: JNIEnv,
-    _class: JClass,
-    activity: JObject,
-) {
+/// Drops the current engine and reloads it on a background thread, reporting
+/// progress via the caller's `onStatusUpdate` callback. Shared by every screen
+/// that changes an engine setting (model, language, threads, custom words), so
+/// all of them reload through the same path the shared engine uses.
+fn spawn_reload(env: JNIEnv, activity: JObject) {
     android_logger::init_once(
         android_logger::Config::default().with_max_level(log::LevelFilter::Info),
     );
@@ -27,4 +23,27 @@ pub unsafe extern "system" fn Java_dev_notune_transcribe_ModelsActivity_reloadMo
         engine::reset();
         let _ = engine::ensure_loaded_from_thread(&vm, &activity_ref);
     });
+}
+
+/// Called after the user changes the model selection (or language hint):
+/// drops the current engine and reloads with the new selection, reporting
+/// progress via the activity's `onStatusUpdate` callback.
+#[no_mangle]
+pub unsafe extern "system" fn Java_dev_notune_transcribe_ModelsActivity_reloadModelNative(
+    env: JNIEnv,
+    _class: JClass,
+    activity: JObject,
+) {
+    spawn_reload(env, activity);
+}
+
+/// Called after the user edits the custom-word list: reloads the engine so the
+/// new initial prompt takes effect on the next transcription.
+#[no_mangle]
+pub unsafe extern "system" fn Java_dev_notune_transcribe_CustomWordsActivity_reloadModelNative(
+    env: JNIEnv,
+    _class: JClass,
+    activity: JObject,
+) {
+    spawn_reload(env, activity);
 }

--- a/src/subtitle.rs
+++ b/src/subtitle.rs
@@ -209,36 +209,49 @@ pub unsafe extern "system" fn Java_dev_notune_transcribe_LiveSubtitleService_ini
                     );
                     gap_pending = true;
                 }
-            } else if let Some(engine_arc) = engine::get_engine() {
-                let audio_secs = job.samples.len() as f64 / SAMPLE_RATE as f64;
-                let started = std::time::Instant::now();
-                let res = engine::transcribe_shared(&engine_arc, job.samples);
-                let elapsed = started.elapsed().as_secs_f64();
-                log::info!(
-                    "Subtitle {} job: {:.1}s audio in {:.2}s (lag {:.1}s)",
-                    if job.is_final { "final" } else { "partial" },
-                    audio_secs,
-                    elapsed,
-                    lag as f64 / SAMPLE_RATE as f64,
-                );
-
-                // Track transcription speed (EMA) so the pusher can predict
-                // job costs; also reflects thermal throttling over time.
-                let sample = (elapsed / audio_secs * 1000.0) as u32;
-                let old = rtf_milli.load(Ordering::SeqCst);
-                let ema = if old == 0 { sample } else { (old * 7 + sample * 3) / 10 };
-                rtf_milli.store(ema, Ordering::SeqCst);
-
-                if let Ok(r) = res {
-                    let text = r.trim();
-                    if !text.is_empty() && gap_pending {
-                        // Mark the dropped stretch so the transcript doesn't
-                        // silently glue unrelated sentences together.
-                        deliver(&mut env, "…", true);
-                        gap_pending = false;
+            } else {
+                // The shared engine may have been unloaded while idle (e.g. the
+                // mic bubble's battery saver cleared it between jobs). Reload
+                // on demand instead of dropping the job, so live subtitles are
+                // never interrupted by an unload.
+                let engine_arc = match engine::get_engine() {
+                    Some(arc) => Some(arc),
+                    None => {
+                        let _ = engine::ensure_loaded(&mut env, service_obj);
+                        engine::get_engine()
                     }
-                    if !text.is_empty() || job.is_final {
-                        deliver(&mut env, text, job.is_final);
+                };
+                if let Some(engine_arc) = engine_arc {
+                    let audio_secs = job.samples.len() as f64 / SAMPLE_RATE as f64;
+                    let started = std::time::Instant::now();
+                    let res = engine::transcribe_shared(&engine_arc, job.samples);
+                    let elapsed = started.elapsed().as_secs_f64();
+                    log::info!(
+                        "Subtitle {} job: {:.1}s audio in {:.2}s (lag {:.1}s)",
+                        if job.is_final { "final" } else { "partial" },
+                        audio_secs,
+                        elapsed,
+                        lag as f64 / SAMPLE_RATE as f64,
+                    );
+
+                    // Track transcription speed (EMA) so the pusher can predict
+                    // job costs; also reflects thermal throttling over time.
+                    let sample = (elapsed / audio_secs * 1000.0) as u32;
+                    let old = rtf_milli.load(Ordering::SeqCst);
+                    let ema = if old == 0 { sample } else { (old * 7 + sample * 3) / 10 };
+                    rtf_milli.store(ema, Ordering::SeqCst);
+
+                    if let Ok(r) = res {
+                        let text = r.trim();
+                        if !text.is_empty() && gap_pending {
+                            // Mark the dropped stretch so the transcript doesn't
+                            // silently glue unrelated sentences together.
+                            deliver(&mut env, "…", true);
+                            gap_pending = false;
+                        }
+                        if !text.is_empty() || job.is_final {
+                            deliver(&mut env, text, job.is_final);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Adds a draggable, persistent floating voice-input bubble.
- Adds explicit visual states: idle microphone, recording stop-square with high-contrast red ring, and loading/processing spinner.
- Adds optional model unloading after an idle interval (Never, 5, 15, or 30 minutes; defaults to 15), with asynchronous reload before the next recording.
- Adds compact bubble sizes (48dp, 56dp, and 72dp).
- Adds optional accessibility-based insertion into a safe focused editable field, with clipboard fallback and password-field avoidance.
- Adds private on-device transcription history with retention settings.
- Adds private custom-word management. Whisper-compatible models receive terms through `initial_prompt`; non-Whisper engines are unchanged.

## Privacy and safety

- All transcription processing remains on-device.
- No raw audio or surrounding text-field contents are stored.
- Accessibility insertion is explicit opt-in and pastes from the clipboard without reading/reconstructing target-field content.

## Testing

- `:app:testDebugUnitTest` passed: 38 tests, including new BubblePrefs, history, and custom-word coverage.
- `:app:compileDebugJavaWithJavac` passed.
- A full GitHub-hosted Android/Rust/NDK debug build passed for the implementation.
- Manually tested and confirmed working on a Samsung Galaxy S25.

## Scope

This branch is based directly on the current upstream `main` and contains only the application feature changes. It deliberately excludes my fork-only GitHub Actions workflow change.

AI assistance was used during implementation and review; functional testing was performed manually on-device.