### PR TITLE
Add runtime-selected Armv8-A backend

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,59 +98,61 @@ dependencies {
 // Rust / cargo-ndk build task
 // ---------------------------------------------------------------------------
 
-val cargoNdkBuild by tasks.registering(Exec::class) {
-    description = "Build Rust native code via cargo-ndk"
+val ndkDir = project.findProperty("ndk.dir")?.toString()
+    ?: System.getenv("ANDROID_NDK_HOME")
+    ?: System.getenv("ANDROID_NDK")
+    ?: android.ndkDirectory.absolutePath
+
+fun nativeVariant(name: String, armArch: String) = tasks.register<Exec>("cargoNdkBuild$name") {
+    description = "Build the $name Rust native backend via cargo-ndk"
     group = "build"
-
-    workingDir = rootProject.projectDir   // Cargo.toml lives at project root
-
-    // Detect NDK path from local.properties or env
-    val ndkDir = project.findProperty("ndk.dir")?.toString()
-        ?: System.getenv("ANDROID_NDK_HOME")
-        ?: System.getenv("ANDROID_NDK")
-        ?: android.ndkDirectory.absolutePath
+    workingDir = rootProject.projectDir
 
     environment("ANDROID_NDK_HOME", ndkDir)
-    // transcribe-cpp-sys builds its C++ core through CMake, whose Android
-    // platform detection needs one of these (ANDROID_NDK_HOME is not enough).
     environment("ANDROID_NDK_ROOT", ndkDir)
     environment("ANDROID_NDK", ndkDir)
-    // ggml cannot autodetect the CPU when cross-compiling and falls back to
-    // baseline armv8-a, losing the dotprod/fp16 kernels its quantized matmuls
-    // rely on (several times slower). armv8.2-a+dotprod+fp16 is supported by
-    // arm64 phones from ~2018 on; the engine refuses older CPUs with a clear
-    // error at load (see check_cpu_features in src/engine.rs) instead of
-    // crashing mid-inference.
-    environment("TRANSCRIBE_CMAKE_ARGS", "-DGGML_CPU_ARM_ARCH=armv8.2-a+dotprod+fp16")
+    environment("CARGO_TARGET_DIR", layout.buildDirectory.dir("rust-$name").get().asFile)
+    environment("TRANSCRIBE_CMAKE_ARGS", "-DGGML_CPU_ARM_ARCH=$armArch")
 
-    val jniLibsDir = project.file("src/main/jniLibs")
-
+    val output = layout.buildDirectory.dir("jni-$name").get().asFile
     commandLine(
         "cargo", "ndk",
         "-t", "arm64-v8a",
-        "-o", jniLibsDir.absolutePath,
+        "-o", output.absolutePath,
         "build", "--release"
     )
+    outputs.dir(output)
+    outputs.upToDateWhen { false }
+}
 
-    // Copy libc++_shared.so from NDK (needed because Rust links against it dynamically)
+val cargoNdkBuildArmv8 = nativeVariant("Armv8", "armv8-a")
+val cargoNdkBuildDotprod = nativeVariant("Dotprod", "armv8.2-a+dotprod+fp16")
+
+val cargoNdkBuild by tasks.registering {
+    description = "Build and package both native CPU backends"
+    group = "build"
+    dependsOn(cargoNdkBuildArmv8, cargoNdkBuildDotprod)
+
     doLast {
-        val ndkPath = environment["ANDROID_NDK_HOME"] as String
-        val libcpp = file("$ndkPath/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so")
-        if (libcpp.exists()) {
-            val destDir = File(jniLibsDir, "arm64-v8a")
-            destDir.mkdirs()
-            libcpp.copyTo(File(destDir, "libc++_shared.so"), overwrite = true)
-            println("Copied libc++_shared.so from NDK")
-        } else {
+        val destDir = project.file("src/main/jniLibs/arm64-v8a")
+        destDir.mkdirs()
+        copy {
+            from(layout.buildDirectory.file("jni-Armv8/arm64-v8a/libandroid_transcribe_app.so"))
+            into(destDir)
+            rename { "libandroid_transcribe_app_armv8.so" }
+        }
+        copy {
+            from(layout.buildDirectory.file("jni-Dotprod/arm64-v8a/libandroid_transcribe_app.so"))
+            into(destDir)
+            rename { "libandroid_transcribe_app_dotprod.so" }
+        }
+
+        val libcpp = file("$ndkDir/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so")
+        if (!libcpp.exists()) {
             throw GradleException("libc++_shared.so not found in NDK at: ${libcpp.absolutePath}")
         }
+        libcpp.copyTo(File(destDir, "libc++_shared.so"), overwrite = true)
     }
-
-    outputs.dir(jniLibsDir)
-    // No input tracking — always run and let cargo's own incremental build
-    // decide what to recompile (a no-op cargo invocation is fast). Without
-    // this, Gradle sees unchanged outputs and skips Rust rebuilds entirely.
-    outputs.upToDateWhen { false }
 }
 
 // Wire the cargo-ndk build into the Android build lifecycle

--- a/app/src/main/java/dev/notune/transcribe/LiveSubtitleService.java
+++ b/app/src/main/java/dev/notune/transcribe/LiveSubtitleService.java
@@ -38,8 +38,7 @@ public class LiveSubtitleService extends Service {
 
     static {
         try {
-            System.loadLibrary("c++_shared");
-            System.loadLibrary("android_transcribe_app");
+            NativeLibraries.load();
         } catch (UnsatisfiedLinkError e) {
             Log.e(TAG, "Failed to load native libraries", e);
         }

--- a/app/src/main/java/dev/notune/transcribe/MainActivity.java
+++ b/app/src/main/java/dev/notune/transcribe/MainActivity.java
@@ -34,12 +34,7 @@ public class MainActivity extends AppCompatActivity {
     private static final int REQ_VOICE_TEST = 202;
 
     static {
-        try {
-            System.loadLibrary("c++_shared");
-        } catch (UnsatisfiedLinkError e) {
-            Log.w(TAG, "Failed to load c++_shared", e);
-        }
-        System.loadLibrary("android_transcribe_app");
+        NativeLibraries.load();
     }
 
     private TextView statusText;

--- a/app/src/main/java/dev/notune/transcribe/ModelsActivity.java
+++ b/app/src/main/java/dev/notune/transcribe/ModelsActivity.java
@@ -55,12 +55,7 @@ public class ModelsActivity extends AppCompatActivity {
     private static final long FREE_SPACE_MARGIN = 64L * 1024 * 1024;
 
     static {
-        try {
-            System.loadLibrary("c++_shared");
-        } catch (UnsatisfiedLinkError e) {
-            Log.w(TAG, "Failed to load c++_shared", e);
-        }
-        System.loadLibrary("android_transcribe_app");
+        NativeLibraries.load();
     }
 
     /** One entry in the curated download list. Names are proper nouns and stay

--- a/app/src/main/java/dev/notune/transcribe/NativeLibraries.java
+++ b/app/src/main/java/dev/notune/transcribe/NativeLibraries.java
@@ -1,0 +1,54 @@
+package dev.notune.transcribe;
+
+import android.util.Log;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/** Loads the fastest native backend supported by this device. */
+final class NativeLibraries {
+    private static final String TAG = "OfflineVoiceInput";
+    private static final long AT_HWCAP = 16;
+    private static final long HWCAP_ASIMDHP = 1L << 10;
+    private static final long HWCAP_ASIMDDP = 1L << 20;
+    private static boolean loaded;
+
+    private NativeLibraries() {}
+
+    static synchronized void load() {
+        if (loaded) {
+            return;
+        }
+
+        System.loadLibrary("c++_shared");
+        String backend = supportsDotprodAndFp16()
+                ? "android_transcribe_app_dotprod"
+                : "android_transcribe_app_armv8";
+        Log.i(TAG, "Loading native backend: " + backend);
+        System.loadLibrary(backend);
+        loaded = true;
+    }
+
+    private static boolean supportsDotprodAndFp16() {
+        try {
+            byte[] auxv = Files.readAllBytes(Paths.get("/proc/self/auxv"));
+            ByteBuffer entries = ByteBuffer.wrap(auxv).order(ByteOrder.nativeOrder());
+            while (entries.remaining() >= 16) {
+                long type = entries.getLong();
+                long value = entries.getLong();
+                if (type == 0) {
+                    break;
+                }
+                if (type == AT_HWCAP) {
+                    return (value & HWCAP_ASIMDHP) != 0 && (value & HWCAP_ASIMDDP) != 0;
+                }
+            }
+        } catch (IOException | RuntimeException e) {
+            Log.w(TAG, "Cannot read CPU capabilities; using Armv8-A backend", e);
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/dev/notune/transcribe/RecognizeActivity.java
+++ b/app/src/main/java/dev/notune/transcribe/RecognizeActivity.java
@@ -21,8 +21,7 @@ public class RecognizeActivity extends AppCompatActivity {
 
     static {
         try {
-            System.loadLibrary("c++_shared");
-            System.loadLibrary("android_transcribe_app");
+            NativeLibraries.load();
         } catch (UnsatisfiedLinkError e) {
             Log.e(TAG, "Failed to load native libraries", e);
         }

--- a/app/src/main/java/dev/notune/transcribe/RustInputMethodService.java
+++ b/app/src/main/java/dev/notune/transcribe/RustInputMethodService.java
@@ -29,8 +29,7 @@ public class RustInputMethodService extends InputMethodService {
 
     static {
         try {
-            System.loadLibrary("c++_shared");
-            System.loadLibrary("android_transcribe_app");
+            NativeLibraries.load();
         } catch (UnsatisfiedLinkError e) {
             Log.e(TAG, "Failed to load native libraries", e);
         }

--- a/app/src/main/java/dev/notune/transcribe/TranscribeFileActivity.java
+++ b/app/src/main/java/dev/notune/transcribe/TranscribeFileActivity.java
@@ -33,8 +33,7 @@ public class TranscribeFileActivity extends AppCompatActivity {
 
     static {
         try {
-            System.loadLibrary("c++_shared");
-            System.loadLibrary("android_transcribe_app");
+            NativeLibraries.load();
         } catch (UnsatisfiedLinkError e) {
             Log.e(TAG, "Failed to load native libraries", e);
         }

--- a/app/src/main/java/dev/notune/transcribe/VoiceRecognitionService.java
+++ b/app/src/main/java/dev/notune/transcribe/VoiceRecognitionService.java
@@ -33,8 +33,7 @@ public class VoiceRecognitionService extends RecognitionService {
 
     static {
         try {
-            System.loadLibrary("c++_shared");
-            System.loadLibrary("android_transcribe_app");
+            NativeLibraries.load();
         } catch (UnsatisfiedLinkError e) {
             Log.e(TAG, "Failed to load native libraries", e);
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ android.nonTransitiveRClass=true
 # If unset, Gradle uses JAVA_HOME. Common locations:
 #   /opt/android-studio/jbr          (Android Studio bundled JBR)
 #   /usr/lib/jvm/java-17-openjdk     (System JDK 17)
-org.gradle.java.home=/opt/android-studio/jbr
+# org.gradle.java.home=/opt/android-studio/jbr

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -400,30 +400,6 @@ fn performance_core_count() -> i32 {
     }
 }
 
-/// CPU features this build's ggml kernels require (see GGML_CPU_ARM_ARCH in
-/// the gradle build): dot-product and half-precision SIMD, present on arm64
-/// cores since ~2018. Without this check, an older CPU would crash with an
-/// illegal instruction mid-inference instead of showing an error.
-#[cfg(target_arch = "aarch64")]
-fn check_cpu_features() -> Result<(), String> {
-    const HWCAP_ASIMHP: libc::c_ulong = 1 << 10; // FEAT_FP16 (asimdhp)
-    const HWCAP_ASIMDDP: libc::c_ulong = 1 << 20; // FEAT_DotProd (asimddp)
-    let hwcap = unsafe { libc::getauxval(libc::AT_HWCAP) };
-    if hwcap & HWCAP_ASIMDDP == 0 || hwcap & HWCAP_ASIMHP == 0 {
-        return Err(
-            "this device's CPU is too old for this app version (needs arm64 \
-             dotprod/fp16, available on phones from ~2018 on)"
-                .to_string(),
-        );
-    }
-    Ok(())
-}
-
-#[cfg(not(target_arch = "aarch64"))]
-fn check_cpu_features() -> Result<(), String> {
-    Ok(())
-}
-
 /// Reads a single-value config file (trimmed); `None` if absent or empty.
 fn read_config(path: &Path) -> Option<String> {
     let s = std::fs::read_to_string(path).ok()?;
@@ -438,11 +414,6 @@ fn read_config(path: &Path) -> Option<String> {
 /// Performs the model load: the selected imported GGUF if any (falling back
 /// to the bundled model on failure), otherwise the bundled model.
 fn do_load(env: &mut JNIEnv, context: &JObject) -> Result<(), String> {
-    if let Err(msg) = check_cpu_features() {
-        notify_status(env, context, &format!("Error: {}", msg));
-        return Err(msg);
-    }
-
     let files_dir = assets::files_dir(env, context).map_err(|e| {
         let msg = format!("Failed to resolve filesDir: {}", e);
         notify_status(env, context, &format!("Error: {}", msg));


### PR DESCRIPTION
## Summary

- build both a baseline `armv8-a` native backend and the existing optimized `armv8.2-a+dotprod+fp16` backend
- detect `AT_HWCAP` at runtime and load the fastest backend supported by the device
- replace the hard CPU rejection with a working fallback for older Arm64 CPUs
- keep dot-product and FP16 kernels enabled on CPUs that expose both features

## Why

The current APK compiles ggml with `armv8.2-a+dotprod+fp16` as a hard minimum and rejects otherwise capable Arm64 devices before loading a model. Devices such as the Moto G32 / Snapdragon 680 support the Android `arm64-v8a` ABI but do not expose the required dot-product and FP16 SIMD feature combination.

This change packages two native libraries in one APK. A shared Java loader reads the process auxiliary vector and selects the optimized library only when both `HWCAP_ASIMDDP` and `HWCAP_ASIMDHP` are present; otherwise it loads the baseline Armv8-A library.

This makes offline transcription practical on these older Armv8-A devices: models such as Moonshine Steamer and Whisper v3 Small can run at acceptable speed even without the dot-product/FP16 backend.

## Validation

- `./gradlew assembleDebug` completed successfully
- APK signature and package metadata verified with Android build tools
- confirmed both native libraries are packaged under `lib/arm64-v8a/`
- disassembly check found no dot-product/FP16-only instructions in the baseline backend and 1,032 optimized instructions in the dotprod/FP16 backend
- manually installed and tested successfully by a human on a Moto G32 with Snapdragon 680

## Development disclosure

This change was vibe-coded with OpenAI Codex. Codex assisted with implementation, inspection, packaging, and ADB installation; functional testing on the target device was performed manually by a human.

## Original prompt

> [CPU Error Explanation](https://chatgpt.com/share/6a7cf75a-869c-83eb-8c33-5f80a8776d15) create a fork of offline voice input, that supports both the existing ISA compute branch and Armv8-A compute branch (auto detect based on device CPU) and compile the APK
