### PR TITLE
Fixes #99 : Keep the keyboard height after a theme change

### DIFF
--- a/app/src/main/java/dev/notune/transcribe/RustInputMethodService.java
+++ b/app/src/main/java/dev/notune/transcribe/RustInputMethodService.java
@@ -337,6 +337,11 @@ public class RustInputMethodService extends InputMethodService {
         if (inputView != null
                 && ThemePrefs.isNight(ThemePrefs.wrapForNight(this, ThemePrefs.getMode(this))) != viewIsNight) {
             setInputView(onCreateInputView());
+            // The insets pass for this window has already run, so the fresh
+            // view never gets the navigation-bar padding onCreateInputView
+            // adds for it — the keyboard then comes back exactly one bottom
+            // inset shorter (48dp here) and the key row is clipped away.
+            inputView.requestApplyInsets();
         }
         // A field is focused and the input connection is live again — commit any
         // text that finished transcribing while nothing was focused.


### PR DESCRIPTION
> [!NOTE]
> This fix is entirely vibe coded. I have verified the diagnosis and the result myself,
> but the code was not hand-written. It is one line tough. 

Fixes #99.

### The change

One line, plus a comment explaining why it is there:

```java
setInputView(onCreateInputView());
inputView.requestApplyInsets();