### PR TITLE
[Accessibility] Add an optional side position for the voice input panel

### DIFF
--- a/app/src/main/java/dev/notune/transcribe/MainActivity.java
+++ b/app/src/main/java/dev/notune/transcribe/MainActivity.java
@@ -10,10 +10,13 @@ import android.speech.RecognizerIntent;
 import android.util.Log;
 import android.util.TypedValue;
 import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.CompoundButton;
 import android.widget.ImageView;
 import android.widget.RadioGroup;
+import android.widget.Spinner;
 import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -27,6 +30,8 @@ import com.google.android.material.snackbar.Snackbar;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class MainActivity extends AppCompatActivity {
     private static final String TAG = "MainActivity";
@@ -96,6 +101,7 @@ public class MainActivity extends AppCompatActivity {
         // Record-in-background defaults to ON; its marker file is the opt-out.
         bindMarkerSwitch(R.id.switch_record_background, "stop_on_hide", true);
         bindMarkerSwitch(R.id.switch_auto_stop, "auto_stop", false);
+        setupRecognizeSideSetting();
 
         // Live subtitle line limit: 2 (default), 4, or 0 = unlimited.
         RadioGroup subsLinesGroup = findViewById(R.id.rg_subtitle_lines);
@@ -296,6 +302,54 @@ public class MainActivity extends AppCompatActivity {
                 }
             } else {
                 marker.delete();
+            }
+        });
+    }
+
+    /**
+     * Binds the switch and the side spinner to the single stored value: no
+     * stored side means the switch is off and the popup keeps its bottom
+     * panel. The switch writes the spinner's side straight away, so it can
+     * never end up on with nothing stored.
+     */
+    private void setupRecognizeSideSetting() {
+        CompoundButton sw = findViewById(R.id.switch_recognize_side);
+        Spinner spinner = findViewById(R.id.spinner_recognize_side);
+
+        // Sides and their labels are read by the same index, and the stored
+        // value is looked up in the list rather than at a hardcoded position.
+        List<String> sides = Arrays.asList(RecognizePrefs.SIDE_RIGHT, RecognizePrefs.SIDE_LEFT);
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(
+                this, android.R.layout.simple_spinner_item, new String[]{
+                        getString(R.string.recognize_side_right),
+                        getString(R.string.recognize_side_left)});
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        spinner.setAdapter(adapter);
+
+        String side = RecognizePrefs.getPanelSide(this);
+        sw.setChecked(!side.isEmpty());
+        spinner.setVisibility(side.isEmpty() ? View.GONE : View.VISIBLE);
+        spinner.setSelection(Math.max(0, sides.indexOf(side)), false);
+
+        sw.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            RecognizePrefs.setPanelSide(this,
+                    isChecked ? sides.get(spinner.getSelectedItemPosition()) : "");
+            spinner.setVisibility(isChecked ? View.VISIBLE : View.GONE);
+        });
+        spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                // A spinner reports its initial selection once it is laid out;
+                // ignoring that while the switch is off keeps it from turning
+                // the setting on by itself.
+                if (!sw.isChecked()) return;
+                String value = sides.get(position);
+                if (value.equals(RecognizePrefs.getPanelSide(MainActivity.this))) return;
+                RecognizePrefs.setPanelSide(MainActivity.this, value);
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
             }
         });
     }

--- a/app/src/main/java/dev/notune/transcribe/RecognizeActivity.java
+++ b/app/src/main/java/dev/notune/transcribe/RecognizeActivity.java
@@ -5,8 +5,11 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.speech.RecognizerIntent;
 import android.util.Log;
+import android.view.Gravity;
+import android.view.View;
 import android.view.WindowManager;
 import android.widget.Button;
+import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.content.pm.PackageManager;
@@ -37,7 +40,23 @@ public class RecognizeActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.recognize_activity);
+        // Opt-in: show the panel as a narrow strip at a screen edge instead of
+        // along the bottom. The side is physical (LEFT/RIGHT, not START/END):
+        // it is the edge the user's hand reaches, so it must not be flipped by
+        // the locale's text direction.
+        String side = RecognizePrefs.getPanelSide(this);
+        if (side.isEmpty()) {
+            setContentView(R.layout.recognize_activity);
+        } else {
+            setContentView(R.layout.recognize_activity_side);
+            if (RecognizePrefs.SIDE_LEFT.equals(side)) {
+                View panel = findViewById(R.id.panel);
+                FrameLayout.LayoutParams lp =
+                        (FrameLayout.LayoutParams) panel.getLayoutParams();
+                lp.gravity = Gravity.LEFT | Gravity.CENTER_VERTICAL;
+                panel.setLayoutParams(lp);
+            }
+        }
 
         // Keep the screen awake for the lifetime of this recording screen so it
         // never sleeps mid-capture and cuts the recording short.

--- a/app/src/main/java/dev/notune/transcribe/RecognizePrefs.java
+++ b/app/src/main/java/dev/notune/transcribe/RecognizePrefs.java
@@ -1,0 +1,53 @@
+package dev.notune.transcribe;
+
+import android.content.Context;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+/**
+ * Position of the voice-input popup panel, stored as a small file in filesDir
+ * like the other settings. No file (the default) keeps the panel along the
+ * bottom; "right"/"left" show it as a narrow vertical panel at that edge.
+ */
+public final class RecognizePrefs {
+    private static final String FILE_NAME = "recognize_side";
+
+    /** Edges the panel can take. Physical, not start/end. */
+    public static final String SIDE_RIGHT = "right";
+    public static final String SIDE_LEFT = "left";
+
+    private RecognizePrefs() {}
+
+    /**
+     * Returns the edge the panel sits on, or "" for the default bottom panel.
+     * Anything else on disk reads as "": the settings screen and the popup read
+     * the same file, so a value one of them cannot make sense of must not leave
+     * them disagreeing about whether the setting is on.
+     */
+    public static String getPanelSide(Context ctx) {
+        File f = new File(ctx.getFilesDir(), FILE_NAME);
+        if (!f.exists()) return "";
+        try {
+            String side = new String(
+                    Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8).trim();
+            return SIDE_RIGHT.equals(side) || SIDE_LEFT.equals(side) ? side : "";
+        } catch (IOException e) {
+            return "";
+        }
+    }
+
+    /** An empty side deletes the file, so absence stays the bottom default. */
+    public static void setPanelSide(Context ctx, String side) {
+        File f = new File(ctx.getFilesDir(), FILE_NAME);
+        if (side == null || side.isEmpty()) {
+            f.delete();
+            return;
+        }
+        try {
+            Files.write(f.toPath(), side.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException ignored) { }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -577,6 +577,51 @@
                             android:layout_height="wrap_content"/>
                     </LinearLayout>
 
+                    <!-- Voice panel at the side -->
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:layout_marginTop="16dp">
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:orientation="vertical"
+                            android:layout_marginEnd="16dp">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/setting_recognize_side"
+                                android:textAppearance="?attr/textAppearanceBodyLarge"/>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/setting_recognize_side_desc"
+                                android:textAppearance="?attr/textAppearanceBodySmall"
+                                android:textColor="?attr/colorOnSurfaceVariant"
+                                android:layout_marginTop="2dp"/>
+                        </LinearLayout>
+
+                        <com.google.android.material.materialswitch.MaterialSwitch
+                            android:id="@+id/switch_recognize_side"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"/>
+                    </LinearLayout>
+
+                    <!-- Which edge; shown only while the switch above is on. -->
+                    <Spinner
+                        android:id="@+id/spinner_recognize_side"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:minHeight="48dp"
+                        android:layout_marginTop="8dp"
+                        android:visibility="gone"/>
+
                     <!-- Subtitle line count -->
                     <LinearLayout
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/recognize_activity_side.xml
+++ b/app/src/main/res/layout/recognize_activity_side.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Edge-anchored variant of recognize_activity.xml, used when the optional
+     "Voice panel at the side" setting is on: a narrow vertical panel that
+     covers less of the calling app than the full-width bottom one. The view
+     ids match the bottom layout so RecognizeActivity drives either without
+     extra wiring — keep the two files in sync when editing one.
+
+     The gravity is a physical edge (right here, flipped to left in Java)
+     rather than start/end on purpose: the user picks the side their hand
+     reaches, which must not follow the text direction of the locale. -->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    android:clickable="true"
+    android:focusable="true">
+
+    <LinearLayout
+        android:id="@+id/panel"
+        android:layout_width="88dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="right|center_vertical"
+        android:layout_margin="16dp"
+        android:orientation="vertical"
+        android:gravity="center_horizontal"
+        android:background="@drawable/bg_voice_panel"
+        android:elevation="8dp"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="4dp">
+
+        <!-- Mic with level glow -->
+        <FrameLayout
+            android:layout_width="64dp"
+            android:layout_height="64dp">
+
+            <dev.notune.transcribe.MicLevelView
+                android:id="@+id/mic_level"
+                android:layout_width="64dp"
+                android:layout_height="64dp"
+                android:layout_gravity="center" />
+
+            <View
+                android:layout_width="44dp"
+                android:layout_height="44dp"
+                android:layout_gravity="center"
+                android:background="@drawable/bg_record_circle" />
+
+            <ImageView
+                android:id="@+id/mic_icon"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_gravity="center"
+                android:src="@drawable/ic_mic"
+                android:contentDescription="@string/section_ime"
+                app:tint="?attr/colorOnPrimaryContainer" />
+        </FrameLayout>
+
+        <TextView
+            android:id="@+id/txt_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="4dp"
+            android:gravity="center_horizontal"
+            android:text="Listening… (tap to stop)"
+            android:textColor="?attr/colorOnSurface"
+            android:textAppearance="?attr/textAppearanceBodySmall" />
+
+        <!-- Close (discard) -->
+        <ImageButton
+            android:id="@+id/btn_close"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="Close"
+            android:src="@drawable/ic_close"
+            app:tint="?attr/colorOnSurfaceVariant" />
+
+    </LinearLayout>
+
+</FrameLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -37,6 +37,11 @@
     <string name="setting_auto_stop">Auto-Stopp bei Stille</string>
     <string name="setting_auto_stop_desc">Spracheingabe-Popup automatisch ~2 Sekunden nach dem Sprechende beenden</string>
 
+    <string name="setting_recognize_side">Sprachpanel an der Seite</string>
+    <string name="setting_recognize_side_desc">Spracheingabe-Popup als schmales senkrechtes Panel am Bildschirmrand statt unten anzeigen</string>
+    <string name="recognize_side_right">Rechts</string>
+    <string name="recognize_side_left">Links</string>
+
     <string name="setting_subtitle_lines">Untertitellänge</string>
     <string name="setting_subtitle_lines_desc">Wie viele Zeilen die Live-Untertitel anzeigen; älterer Text scrollt weg</string>
     <string name="subtitle_lines_2">2 Zeilen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -37,6 +37,11 @@
     <string name="setting_auto_stop">Parada automática tras silencio</string>
     <string name="setting_auto_stop_desc">Cerrar la ventana de entrada de voz automáticamente ~2 segundos después de dejar de hablar</string>
 
+    <string name="setting_recognize_side">Panel de voz en el lateral</string>
+    <string name="setting_recognize_side_desc">Mostrar la ventana de entrada de voz como un panel vertical estrecho en el borde de la pantalla en lugar de abajo</string>
+    <string name="recognize_side_right">Derecha</string>
+    <string name="recognize_side_left">Izquierda</string>
+
     <string name="setting_subtitle_lines">Longitud de subtítulos</string>
     <string name="setting_subtitle_lines_desc">Cuántas líneas muestran los subtítulos en directo; el texto antiguo se desplaza</string>
     <string name="subtitle_lines_2">2 líneas</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -37,6 +37,11 @@
     <string name="setting_auto_stop">Arrêt automatique après un silence</string>
     <string name="setting_auto_stop_desc">Fermer automatiquement la fenêtre de saisie vocale ~2 secondes après la fin de la parole</string>
 
+    <string name="setting_recognize_side">Panneau vocal sur le côté</string>
+    <string name="setting_recognize_side_desc">Afficher la fenêtre de saisie vocale comme un panneau vertical étroit au bord de l\'écran plutôt qu\'en bas</string>
+    <string name="recognize_side_right">Droite</string>
+    <string name="recognize_side_left">Gauche</string>
+
     <string name="setting_subtitle_lines">Longueur des sous-titres</string>
     <string name="setting_subtitle_lines_desc">Nombre de lignes affichées par les sous-titres en direct ; le texte plus ancien défile</string>
     <string name="subtitle_lines_2">2 lignes</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -37,6 +37,11 @@
     <string name="setting_auto_stop">Arresto automatico dopo il silenzio</string>
     <string name="setting_auto_stop_desc">Chiudi la finestra di immissione vocale automaticamente ~2 secondi dopo la fine del parlato</string>
 
+    <string name="setting_recognize_side">Pannello vocale a lato</string>
+    <string name="setting_recognize_side_desc">Mostra la finestra di immissione vocale come un pannello verticale stretto sul bordo dello schermo invece che in basso</string>
+    <string name="recognize_side_right">Destra</string>
+    <string name="recognize_side_left">Sinistra</string>
+
     <string name="setting_subtitle_lines">Lunghezza sottotitoli</string>
     <string name="setting_subtitle_lines_desc">Quante righe mostrano i sottotitoli in tempo reale; il testo più vecchio scorre via</string>
     <string name="subtitle_lines_2">2 righe</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -37,6 +37,11 @@
     <string name="setting_auto_stop">Parada automática após silêncio</string>
     <string name="setting_auto_stop_desc">Fechar a janela de entrada de voz automaticamente ~2 segundos após você parar de falar</string>
 
+    <string name="setting_recognize_side">Painel de voz na lateral</string>
+    <string name="setting_recognize_side_desc">Mostrar a janela de entrada de voz como um painel vertical estreito na borda da tela em vez de na parte inferior</string>
+    <string name="recognize_side_right">Direita</string>
+    <string name="recognize_side_left">Esquerda</string>
+
     <string name="setting_subtitle_lines">Comprimento das legendas</string>
     <string name="setting_subtitle_lines_desc">Quantas linhas as legendas ao vivo mostram; o texto mais antigo rola para fora</string>
     <string name="subtitle_lines_2">2 linhas</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -37,6 +37,11 @@
     <string name="setting_auto_stop">Автостоп при тишине</string>
     <string name="setting_auto_stop_desc">Автоматически закрывать окно голосового ввода примерно через 2 секунды после окончания речи</string>
 
+    <string name="setting_recognize_side">Голосовая панель сбоку</string>
+    <string name="setting_recognize_side_desc">Показывать окно голосового ввода как узкую вертикальную панель у края экрана вместо нижней части</string>
+    <string name="recognize_side_right">Справа</string>
+    <string name="recognize_side_left">Слева</string>
+
     <string name="setting_subtitle_lines">Длина субтитров</string>
     <string name="setting_subtitle_lines_desc">Сколько строк показывают субтитры; более старый текст прокручивается</string>
     <string name="subtitle_lines_2">2 строки</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,11 @@
     <string name="setting_auto_stop">Auto-stop after silence</string>
     <string name="setting_auto_stop_desc">End the voice input popup automatically ~2 seconds after you stop speaking</string>
 
+    <string name="setting_recognize_side">Voice panel at the side</string>
+    <string name="setting_recognize_side_desc">Show the voice input popup as a narrow vertical panel at the screen edge instead of along the bottom</string>
+    <string name="recognize_side_right">Right</string>
+    <string name="recognize_side_left">Left</string>
+
     <string name="setting_subtitle_lines">Subtitle length</string>
     <string name="setting_subtitle_lines_desc">How many lines the live subtitles show; older text scrolls away</string>
     <string name="subtitle_lines_2">2 lines</string>


### PR DESCRIPTION
> [!NOTE]
> This was entirely vibe coded. I have used it daily for
> a couple of weeks and also verified the behaviour on an emulator myself, but
> the code was not hand-written. The following report is mainly AI generated.

Closes #101.

A new setting, off by default, that shows the `RECOGNIZE_SPEECH` popup as
a narrow vertical panel at a screen edge instead of along the bottom,
with a spinner to pick the edge. With the setting off, nothing changes.

### Changes

- **`recognize_activity_side.xml`** — a second layout for the edge
  arrangement. It reuses the same view ids as `recognize_activity.xml`,
  so `RecognizeActivity` drives either one without extra wiring: the only
  Java change is which layout it inflates.
- **`RecognizeActivity`** — picks the layout in `onCreate`, and flips the
  panel's gravity for a left-handed layout.
- **`RecognizePrefs`** — the stored side, following the `SubtitlePrefs` /
  `ThemePrefs` shape (a small file in `filesDir`). Absent means the
  bottom panel, so an existing install is unaffected.
- **`MainActivity` + `activity_main.xml`** — the switch and its spinner,
  next to the auto-stop row since both are popup settings. The spinner
  wiring follows `ModelsActivity`'s existing pattern.
- **Strings** — new entries in all seven locale files.

### Notes

**One value file backs both controls.** The switch and the spinner are
two views of the same stored value, so there is no state where the switch
is on but no side is stored. Turning it off forgets the chosen side,
which seemed a fair trade for not having a second marker to keep in sync.

The panel is recreated per dictation and the activity declares
`configChanges`, so the setting applies on the next dictation with no
lifecycle handling needed.

The status line can carry long text ("Error: …", the microphone
permission message), which wraps in the narrower column and makes the
panel taller. I checked those cases read fine; it is the main trade-off
of the narrow layout.