### PR TITLE
Add simple manual text correction features

### DIFF
--- a/app/src/main/java/dev/notune/transcribe/MainActivity.java
+++ b/app/src/main/java/dev/notune/transcribe/MainActivity.java
@@ -97,6 +97,14 @@ public class MainActivity extends AppCompatActivity {
         bindMarkerSwitch(R.id.switch_record_background, "stop_on_hide", true);
         bindMarkerSwitch(R.id.switch_auto_stop, "auto_stop", false);
 
+        // Voice-keyboard layout. The editing keys need the bottom row for
+        // punctuation, so they push the keyboard-switch key up to the status row:
+        // that switch shows as on and locked while they are enabled.
+        CompoundButton kbKeyTop = bindMarkerSwitch(R.id.switch_ime_kb_key_top, "ime_kb_key_top", false);
+        CompoundButton editRow = bindMarkerSwitch(R.id.switch_ime_edit_row, "ime_edit_row", false,
+                (button, isChecked) -> showKeyboardKeyImplied(kbKeyTop, isChecked));
+        showKeyboardKeyImplied(kbKeyTop, editRow.isChecked());
+
         // Live subtitle line limit: 2 (default), 4, or 0 = unlimited.
         RadioGroup subsLinesGroup = findViewById(R.id.rg_subtitle_lines);
         int subsLines = SubtitlePrefs.getMaxLines(this);
@@ -282,11 +290,17 @@ public class MainActivity extends AppCompatActivity {
      * Binds a switch to a marker file in filesDir. With {@code inverted}, the
      * file's presence means the switch is OFF (used for default-on settings).
      */
-    private void bindMarkerSwitch(int switchId, String fileName, boolean inverted) {
+    private CompoundButton bindMarkerSwitch(int switchId, String fileName, boolean inverted) {
+        return bindMarkerSwitch(switchId, fileName, inverted, null);
+    }
+
+    /** As above, with {@code extra} run after the marker file has been updated. */
+    private CompoundButton bindMarkerSwitch(int switchId, String fileName, boolean inverted,
+                                            CompoundButton.OnCheckedChangeListener extra) {
         CompoundButton sw = findViewById(switchId);
         File marker = new File(getFilesDir(), fileName);
         sw.setChecked(marker.exists() != inverted);
-        sw.setOnCheckedChangeListener((buttonView, isChecked) -> {
+        CompoundButton.OnCheckedChangeListener listener = (buttonView, isChecked) -> {
             boolean shouldExist = isChecked != inverted;
             if (shouldExist) {
                 try {
@@ -297,7 +311,32 @@ public class MainActivity extends AppCompatActivity {
             } else {
                 marker.delete();
             }
-        });
+            if (extra != null) extra.onCheckedChanged(buttonView, isChecked);
+        };
+        // Kept so a switch can be moved for display only, without writing.
+        sw.setTag(listener);
+        sw.setOnCheckedChangeListener(listener);
+        return sw;
+    }
+
+    /**
+     * The editing keys imply the keyboard-switch key in the status row, so its
+     * switch reads as on and locked while they are enabled. Only the display is
+     * forced: writing the marker would overwrite the user's own choice, and
+     * turning the editing keys back off could not then restore it.
+     * RustInputMethodService derives the same implication when it reads them.
+     */
+    private void showKeyboardKeyImplied(CompoundButton kbKeyTop, boolean editRowEnabled) {
+        kbKeyTop.setEnabled(!editRowEnabled);
+        boolean chosen = new File(getFilesDir(), "ime_kb_key_top").exists();
+        boolean shown = chosen || editRowEnabled;
+        if (kbKeyTop.isChecked() == shown) return;
+        // Detach so this display-only change never reaches the marker file.
+        CompoundButton.OnCheckedChangeListener saved =
+                (CompoundButton.OnCheckedChangeListener) kbKeyTop.getTag();
+        kbKeyTop.setOnCheckedChangeListener(null);
+        kbKeyTop.setChecked(shown);
+        kbKeyTop.setOnCheckedChangeListener(saved);
     }
 
     private void checkAndRequestPermissions() {

--- a/app/src/main/java/dev/notune/transcribe/RustInputMethodService.java
+++ b/app/src/main/java/dev/notune/transcribe/RustInputMethodService.java
@@ -19,6 +19,8 @@ import android.view.inputmethod.EditorInfo;
 import android.content.res.ColorStateList;
 import android.view.ContextThemeWrapper;
 import java.io.File;
+import java.text.BreakIterator;
+import java.util.Locale;
 
 import com.google.android.material.color.DynamicColors;
 import com.google.android.material.color.MaterialColors;
@@ -42,15 +44,29 @@ public class RustInputMethodService extends InputMethodService {
     private android.widget.ImageView micIcon;
     private ProgressBar progressBar;
     private View backspaceButton;
+    private View backspaceNavButton;
     private View spaceButton;
     private View enterButton;
     private View switchKeyboardButton;
     private View inputView;
     private MicLevelView micLevelView;
     private View recordCircle;
+    // Optional text-editing keys (see the settings on the main screen).
+    private View shiftButton;
+    private View wordLeftButton;
+    private View charLeftButton;
+    private View charRightButton;
+    private View wordRightButton;
+    private View selectButton;
+    private View commaButton;
+    private View periodButton;
     // Night flag the current input view was inflated with, so it can be rebuilt
     // if the theme preference changes while this process stays alive.
     private boolean viewIsNight = false;
+    // Same idea for the two optional-key settings: they change the layout, and
+    // this process outlives the app screen where they are toggled.
+    private boolean viewKbKeyTop = false;
+    private boolean viewEditRow = false;
     private Handler mainHandler;
     private boolean isRecording = false;
     private boolean pendingSwitchBack = false;
@@ -60,6 +76,42 @@ public class RustInputMethodService extends InputMethodService {
     private static final long REPEAT_INTERVAL = 50; // ms between repeats
     private Runnable backspaceRepeatRunnable;
     private Runnable spaceRepeatRunnable;
+    // One per direction: sharing a single field would let a second finger
+    // overwrite the first key's runnable, orphaning it to repeat forever.
+    private Runnable charLeftRepeatRunnable;
+    private Runnable charRightRepeatRunnable;
+    // How much text either side of the cursor to inspect for word and paragraph
+    // jumps. Editors only share a window of their content with the IME, so this
+    // is a bound on the search, not on the field.
+    private static final int EDIT_TEXT_WINDOW = 4096;
+    // Cursor position, kept current by onUpdateSelection.
+    private int selStart = 0;
+    private int selEnd = 0;
+    // The range this service last asked for. onUpdateSelection compares against
+    // it to tell its own moves from the user tapping into the text, which has to
+    // cancel the cycles below — they are anchored to the previous selection.
+    private int expectedSelStart = -1;
+    private int expectedSelEnd = -1;
+    // Set when we asked for a selection whose result only the editor knows
+    // (select-all), so the one update it produces isn't mistaken for the user's.
+    private boolean selectionChangePending = false;
+    // While on, the cursor keys extend the selection from selectionAnchor
+    // instead of moving the caret.
+    private boolean selectionMode = false;
+    private int selectionAnchor = 0;
+    // Select key: 1 = last dictation, 2 = whole field, 0 = nothing (restoring
+    // the caret to where it was when the cycle started).
+    private int selectCycleStep = 0;
+    private int selectCycleCaret = 0;
+    // Range of the last committed transcription, or -1 once any edit has made
+    // the offsets meaningless.
+    private int lastDictationStart = -1;
+    private int lastDictationEnd = -1;
+    // Case key: 1 = capitalized, 2 = upper, 3 = lower. Each step is computed
+    // from the text as it was before the cycle started, so capitalizing an
+    // already-uppercase word still works.
+    private int caseCycleStep = 0;
+    private String caseCycleOriginal = null;
     private final AudioFocusPauser audioPauser = new AudioFocusPauser();
     private boolean pauseAudioActive = false;
     // Whether an editor is currently focused/started for input. Tracked via
@@ -117,6 +169,11 @@ public class RustInputMethodService extends InputMethodService {
                 return insets;
             });
 
+            // Which optional keys to show. Captured here so onStartInputView can
+            // tell when the user has changed them behind this view's back.
+            viewKbKeyTop = isKbKeyTopEnabled();
+            viewEditRow = isEditRowEnabled();
+
             statusView = view.findViewById(R.id.ime_status_text);
             progressBar = view.findViewById(R.id.ime_progress);
             recordContainer = view.findViewById(R.id.ime_record_container);
@@ -125,11 +182,23 @@ public class RustInputMethodService extends InputMethodService {
             recordCircle = view.findViewById(R.id.ime_record_circle);
             hintView = view.findViewById(R.id.ime_hint);
             backspaceButton = view.findViewById(R.id.ime_backspace);
+            backspaceNavButton = view.findViewById(R.id.ime_backspace_nav);
             spaceButton = view.findViewById(R.id.ime_space);
             enterButton = view.findViewById(R.id.ime_enter);
             switchKeyboardButton = view.findViewById(R.id.ime_switch_keyboard);
+            shiftButton = view.findViewById(R.id.ime_shift);
+            wordLeftButton = view.findViewById(R.id.ime_word_left);
+            charLeftButton = view.findViewById(R.id.ime_char_left);
+            charRightButton = view.findViewById(R.id.ime_char_right);
+            wordRightButton = view.findViewById(R.id.ime_word_right);
+            selectButton = view.findViewById(R.id.ime_select);
+            commaButton = view.findViewById(R.id.ime_comma);
+            periodButton = view.findViewById(R.id.ime_period);
 
-            switchKeyboardButton.setOnClickListener(v -> {
+            applyKeyLayout(view);
+
+            // Same action from either position, depending on the setting.
+            View.OnClickListener switchKeyboard = v -> {
                 if (isRecording) {
                     pendingSwitchBack = true;
                     stopRecording();
@@ -137,7 +206,14 @@ public class RustInputMethodService extends InputMethodService {
                 } else {
                     switchToPreviousInputMethod();
                 }
-            });
+            };
+            switchKeyboardButton.setOnClickListener(switchKeyboard);
+            view.findViewById(R.id.ime_switch_keyboard_top).setOnClickListener(switchKeyboard);
+
+            // Every key is wired whether or not it is currently shown, so that
+            // toggling a setting is a visibility change on the live view rather
+            // than a rebuild.
+            wireEditingKeys();
 
             // Key repeat runnable for backspace
             backspaceRepeatRunnable = new Runnable() {
@@ -164,9 +240,11 @@ public class RustInputMethodService extends InputMethodService {
                 }
             };
 
-            backspaceButton.setOnTouchListener((v, event) -> {
+            // Backspace exists in both rows; only one of them is ever visible.
+            View.OnTouchListener backspaceTouch = (v, event) -> {
                 switch (event.getAction()) {
                     case MotionEvent.ACTION_DOWN:
+                        onTextEdited();
                         InputConnection ic = getCurrentInputConnection();
                         if (ic != null) {
                             ic.sendKeyEvent(new android.view.KeyEvent(android.view.KeyEvent.ACTION_DOWN, android.view.KeyEvent.KEYCODE_DEL));
@@ -180,11 +258,14 @@ public class RustInputMethodService extends InputMethodService {
                         return true;
                 }
                 return false;
-            });
+            };
+            backspaceButton.setOnTouchListener(backspaceTouch);
+            backspaceNavButton.setOnTouchListener(backspaceTouch);
 
             spaceButton.setOnTouchListener((v, event) -> {
                 switch (event.getAction()) {
                     case MotionEvent.ACTION_DOWN:
+                        onTextEdited();
                         InputConnection ic = getCurrentInputConnection();
                         if (ic != null) {
                             ic.commitText(" ", 1);
@@ -200,6 +281,7 @@ public class RustInputMethodService extends InputMethodService {
             });
 
             enterButton.setOnClickListener(v -> {
+                onTextEdited();
                 InputConnection ic = getCurrentInputConnection();
                 if (ic != null) {
                     android.view.inputmethod.EditorInfo editorInfo = getCurrentInputEditorInfo();
@@ -326,17 +408,32 @@ public class RustInputMethodService extends InputMethodService {
     public void onStartInput(EditorInfo attribute, boolean restarting) {
         super.onStartInput(attribute, restarting);
         inputActive = true;
+        // A different field means the remembered offsets point at nothing, and a
+        // selection mode left on from the last field would surprise the user.
+        resetEditingState(attribute);
     }
 
     @Override
     public void onStartInputView(EditorInfo info, boolean restarting) {
         super.onStartInputView(info, restarting);
         inputActive = true;
-        // Rebuild the keyboard if the theme preference changed while this
-        // (long-lived) IME process stayed alive, so it matches the app setting.
-        if (inputView != null
-                && ThemePrefs.isNight(ThemePrefs.wrapForNight(this, ThemePrefs.getMode(this))) != viewIsNight) {
+        // Both the theme and the optional-key settings can change while this
+        // (long-lived) IME process stays alive, so check them every time the
+        // keyboard is about to be shown.
+        boolean night = ThemePrefs.isNight(ThemePrefs.wrapForNight(this, ThemePrefs.getMode(this)));
+        if (inputView != null && night != viewIsNight) {
+            // A theme change needs a fresh inflate to re-resolve every attribute.
+            cancelKeyRepeats();
             setInputView(onCreateInputView());
+        } else if (inputView != null
+                && (isKbKeyTopEnabled() != viewKbKeyTop || isEditRowEnabled() != viewEditRow)) {
+            // The keys are all inflated already, so this is only a visibility
+            // change. Swapping in a whole new view here would leave the added row
+            // undrawn, because the input window has already been sized.
+            viewKbKeyTop = isKbKeyTopEnabled();
+            viewEditRow = isEditRowEnabled();
+            cancelKeyRepeats();
+            applyKeyLayout(inputView);
         }
         // A field is focused and the input connection is live again — commit any
         // text that finished transcribing while nothing was focused.
@@ -349,6 +446,37 @@ public class RustInputMethodService extends InputMethodService {
         inputActive = false;
     }
 
+    @Override
+    public void onUpdateSelection(int oldSelStart, int oldSelEnd, int newSelStart, int newSelEnd,
+                                  int candidatesStart, int candidatesEnd) {
+        super.onUpdateSelection(oldSelStart, oldSelEnd, newSelStart, newSelEnd,
+                candidatesStart, candidatesEnd);
+        selStart = newSelStart;
+        selEnd = newSelEnd;
+        // Someone other than us moved the caret — the user tapped into the text,
+        // or the app edited it. Both cycles remember a range and a snapshot of
+        // the text that was in it, so continuing them would apply the old text
+        // to the new selection.
+        if (selectionChangePending) {
+            selectionChangePending = false;
+            expectedSelStart = newSelStart;
+            expectedSelEnd = newSelEnd;
+        } else if (newSelStart != expectedSelStart || newSelEnd != expectedSelEnd) {
+            selectCycleStep = 0;
+            caseCycleStep = 0;
+        }
+    }
+
+    /**
+     * Moves the selection and records where we put it, so the mirror above stays
+     * in step and onUpdateSelection can recognise the change as ours.
+     */
+    private void setSelectionTracked(InputConnection ic, int start, int end) {
+        ic.setSelection(start, end);
+        selStart = expectedSelStart = start;
+        selEnd = expectedSelEnd = end;
+    }
+
     private void updateRecordButtonUI(boolean recording) {
         isRecording = recording;
         // Keep the screen awake while recording so it never sleeps mid-capture
@@ -358,7 +486,9 @@ public class RustInputMethodService extends InputMethodService {
         }
         tintRecordButton(recording);
         if (recording) {
-            statusView.setText("Listening...");
+            // With the editing keys on there is no room for the hint under the
+            // mic, so the status line carries the instruction instead.
+            statusView.setText(viewEditRow ? "Listening… (tap to stop)" : "Listening...");
             hintView.setText("Tap to Stop");
         } else {
             statusView.setText("Processing...");
@@ -497,17 +627,35 @@ public class RustInputMethodService extends InputMethodService {
     // Commits transcribed text into the active input connection, optionally
     // selecting it afterwards (select_transcription setting).
     private void commitTranscribedText(InputConnection ic, String committed) {
+        // Dictating over a selection replaces it, so any selection mode the user
+        // left on has served its purpose by now, and both cycles are anchored to
+        // text that is no longer there.
+        if (selectionMode) {
+            selectionMode = false;
+            updateEditingKeyTints();
+        }
+        selectCycleStep = 0;
+        caseCycleStep = 0;
         ic.commitText(committed, 1);
 
-        if (!pendingSwitchBack && new File(getFilesDir(), "select_transcription").exists()) {
-            android.view.inputmethod.ExtractedText et = ic.getExtractedText(
-                new android.view.inputmethod.ExtractedTextRequest(), 0);
-            if (et != null) {
-                int end = et.selectionStart;
-                int start = end - committed.length();
-                if (start >= 0) {
-                    ic.setSelection(start, end);
-                }
+        // Extracting the field is a round trip that copies its text, so only ask
+        // when something will read the answer: the select key's "just what I
+        // dictated" step, or the select-transcription setting.
+        boolean selectTranscription = !pendingSwitchBack
+                && new File(getFilesDir(), "select_transcription").exists();
+        if (!viewEditRow && !selectTranscription) return;
+
+        android.view.inputmethod.ExtractedText et = ic.getExtractedText(
+            new android.view.inputmethod.ExtractedTextRequest(), 0);
+        if (et != null) {
+            int end = et.selectionStart;
+            int start = end - committed.length();
+            // Remembered so the select key can offer "just what I dictated"
+            // before falling back to the whole field.
+            lastDictationStart = start >= 0 ? start : -1;
+            lastDictationEnd = start >= 0 ? end : -1;
+            if (selectTranscription && start >= 0) {
+                ic.setSelection(start, end);
             }
         }
     }
@@ -529,8 +677,438 @@ public class RustInputMethodService extends InputMethodService {
         }
     }
 
+    private int dp(int value) {
+        return Math.round(value * getResources().getDisplayMetrics().density);
+    }
+
+    /**
+     * Shows the keys the user has opted into. Every key is inflated either way
+     * (see ime_layout.xml), so this only flips visibility — no findViewById can
+     * come back null for an arrangement that isn't in use.
+     */
+    private void applyKeyLayout(View view) {
+        view.findViewById(R.id.ime_switch_keyboard_top)
+                .setVisibility(viewKbKeyTop ? View.VISIBLE : View.GONE);
+        switchKeyboardButton.setVisibility(viewKbKeyTop ? View.GONE : View.VISIBLE);
+
+        view.findViewById(R.id.ime_nav_row).setVisibility(viewEditRow ? View.VISIBLE : View.GONE);
+        selectButton.setVisibility(viewEditRow ? View.VISIBLE : View.GONE);
+        commaButton.setVisibility(viewEditRow ? View.VISIBLE : View.GONE);
+        periodButton.setVisibility(viewEditRow ? View.VISIBLE : View.GONE);
+        // Backspace moved up to the cursor row; the status line takes over the
+        // hint's "tap to stop" duty.
+        view.findViewById(R.id.ime_backspace)
+                .setVisibility(viewEditRow ? View.GONE : View.VISIBLE);
+        hintView.setVisibility(viewEditRow ? View.GONE : View.VISIBLE);
+
+        // Enter ends the bottom row once backspace leaves it, so drop the
+        // trailing gap that would otherwise sit against the edge.
+        LinearLayout.LayoutParams enterParams =
+                (LinearLayout.LayoutParams) enterButton.getLayoutParams();
+        enterParams.width = dp(viewEditRow ? 52 : 64);
+        enterParams.setMarginEnd(viewEditRow ? 0 : dp(8));
+        enterButton.setLayoutParams(enterParams);
+
+        // The optional rows take their height out of the record area rather than
+        // adding to it, so the keyboard never grows and shoves the host app's
+        // layout upward.
+        android.view.ViewGroup.LayoutParams recordParams = recordContainer.getLayoutParams();
+        recordParams.height = dp(viewEditRow ? 124 : (viewKbKeyTop ? 176 : 200));
+        recordContainer.setLayoutParams(recordParams);
+    }
+
+    /** Click handlers for the optional cursor, selection and punctuation keys. */
+    private void wireEditingKeys() {
+        charLeftButton.setOnTouchListener(cursorRepeatListener(-1));
+        charRightButton.setOnTouchListener(cursorRepeatListener(1));
+
+        wordLeftButton.setOnClickListener(v -> moveCaret(-1, BY_WORD));
+        wordRightButton.setOnClickListener(v -> moveCaret(1, BY_WORD));
+        // Holding a word key overshoots to the paragraph edge. This is why the
+        // word keys don't repeat on hold the way the character keys do.
+        wordLeftButton.setOnLongClickListener(v -> {
+            moveCaret(-1, BY_PARAGRAPH);
+            return true;
+        });
+        wordRightButton.setOnLongClickListener(v -> {
+            moveCaret(1, BY_PARAGRAPH);
+            return true;
+        });
+
+        selectButton.setOnClickListener(v -> onSelectKey());
+        // Returning true both consumes the click that would otherwise follow on
+        // release and gets the long-press haptic for free.
+        selectButton.setOnLongClickListener(v -> {
+            toggleSelectionMode();
+            return true;
+        });
+
+        shiftButton.setOnClickListener(v -> onCaseKey());
+
+        commaButton.setOnClickListener(v -> commitCharacter(","));
+        periodButton.setOnClickListener(v -> commitCharacter("."));
+        commaButton.setOnLongClickListener(v -> {
+            commitCharacter("?");
+            return true;
+        });
+        periodButton.setOnLongClickListener(v -> {
+            commitCharacter("!");
+            return true;
+        });
+    }
+
+    /**
+     * Hold-to-repeat for one cursor key. The runnable is created once and owned
+     * by that key, mirroring the backspace and space keys: a runnable created
+     * per touch and stored in a field shared with the opposite key is orphaned
+     * when the other key is pressed, and then repeats until the process dies.
+     */
+    private View.OnTouchListener cursorRepeatListener(int direction) {
+        Runnable repeat = new Runnable() {
+            @Override
+            public void run() {
+                moveCaret(direction, BY_CHAR);
+                mainHandler.postDelayed(this, REPEAT_INTERVAL);
+            }
+        };
+        if (direction < 0) {
+            charLeftRepeatRunnable = repeat;
+        } else {
+            charRightRepeatRunnable = repeat;
+        }
+        return (v, event) -> {
+            switch (event.getAction()) {
+                case MotionEvent.ACTION_DOWN:
+                    moveCaret(direction, BY_CHAR);
+                    mainHandler.postDelayed(repeat, REPEAT_INITIAL_DELAY);
+                    return true;
+                case MotionEvent.ACTION_UP:
+                case MotionEvent.ACTION_CANCEL:
+                    mainHandler.removeCallbacks(repeat);
+                    return true;
+            }
+            return false;
+        };
+    }
+
+    private void cancelKeyRepeats() {
+        if (backspaceRepeatRunnable != null) mainHandler.removeCallbacks(backspaceRepeatRunnable);
+        if (spaceRepeatRunnable != null) mainHandler.removeCallbacks(spaceRepeatRunnable);
+        if (charLeftRepeatRunnable != null) mainHandler.removeCallbacks(charLeftRepeatRunnable);
+        if (charRightRepeatRunnable != null) mainHandler.removeCallbacks(charRightRepeatRunnable);
+    }
+
+    private static final int BY_CHAR = 0;
+    private static final int BY_WORD = 1;
+    private static final int BY_PARAGRAPH = 2;
+
+    /**
+     * Moves the caret, or extends the selection while selection mode is on.
+     * With a selection but no selection mode the keys collapse it to the edge
+     * they point at, which is what every text editor does.
+     */
+    private void moveCaret(int direction, int granularity) {
+        InputConnection ic = getCurrentInputConnection();
+        if (ic == null) return;
+        selectCycleStep = 0;
+        caseCycleStep = 0;
+
+        if (!selectionMode && selStart != selEnd) {
+            int edge = direction > 0 ? Math.max(selStart, selEnd) : Math.min(selStart, selEnd);
+            setSelectionTracked(ic, edge, edge);
+            updateEditingKeyTints();
+            return;
+        }
+
+        // A plain character step is best left to the editor: it knows where the
+        // text ends and needs no round trip to read it.
+        if (granularity == BY_CHAR && !selectionMode) {
+            sendDownUpKeyEvents(direction > 0
+                    ? android.view.KeyEvent.KEYCODE_DPAD_RIGHT
+                    : android.view.KeyEvent.KEYCODE_DPAD_LEFT);
+            return;
+        }
+
+        int caret = selectionMode && selStart != selectionAnchor ? selStart : selEnd;
+        int target;
+        if (granularity == BY_CHAR) {
+            // Extending past the last character: setSelection would be ignored
+            // out of range and no correction would arrive, so the mirrored end
+            // would drift past the text and the opposite key would look dead.
+            if (direction > 0 && caret >= selEnd) {
+                CharSequence after = ic.getTextAfterCursor(1, 0);
+                if (after == null || after.length() == 0) return;
+            }
+            target = Math.max(0, caret + direction);
+        } else {
+            android.view.inputmethod.ExtractedTextRequest req =
+                    new android.view.inputmethod.ExtractedTextRequest();
+            // Bound what the editor has to marshal; startOffset below puts the
+            // window back into whole-field coordinates.
+            req.hintMaxChars = EDIT_TEXT_WINDOW;
+            android.view.inputmethod.ExtractedText et = ic.getExtractedText(req, 0);
+            if (et == null || et.text == null) {
+                // Password fields and editors with their own text handling don't
+                // extract; fall back to a character step rather than doing nothing.
+                target = Math.max(0, caret + direction);
+            } else {
+                int offset = Math.max(0, et.startOffset);
+                String text = et.text.toString();
+                int local = Math.max(0, Math.min(text.length(), caret - offset));
+                target = offset + (granularity == BY_WORD
+                        ? wordBoundary(text, local, direction)
+                        : paragraphEdge(text, local, direction));
+            }
+        }
+
+        if (selectionMode) {
+            setSelectionTracked(ic, Math.min(selectionAnchor, target),
+                    Math.max(selectionAnchor, target));
+        } else {
+            setSelectionTracked(ic, target, target);
+        }
+    }
+
+    /**
+     * Next word boundary in {@code text} from {@code from}. Separator runs are
+     * skipped so that a jump always lands on a word rather than on the space
+     * before it. BreakIterator does the locale-specific part.
+     */
+    private int wordBoundary(String text, int from, int direction) {
+        BreakIterator it = BreakIterator.getWordInstance(Locale.getDefault());
+        it.setText(text);
+        int pos = from;
+        while (true) {
+            int next = direction < 0 ? it.preceding(pos) : it.following(pos);
+            if (next == BreakIterator.DONE) return direction < 0 ? 0 : text.length();
+            if (hasLetterOrDigit(text, Math.min(pos, next), Math.max(pos, next))) return next;
+            pos = next;
+        }
+    }
+
+    private boolean hasLetterOrDigit(String text, int from, int to) {
+        for (int i = from; i < to; i++) {
+            if (Character.isLetterOrDigit(text.charAt(i))) return true;
+        }
+        return false;
+    }
+
+    /** Start or end of the current paragraph; the whole field if it has no newlines. */
+    private int paragraphEdge(String text, int from, int direction) {
+        if (direction < 0) {
+            int nl = text.lastIndexOf('\n', Math.max(0, from - 1));
+            return nl < 0 ? 0 : nl + 1;
+        }
+        int nl = text.indexOf('\n', from);
+        return nl < 0 ? text.length() : nl;
+    }
+
+    /**
+     * Select key: successive taps widen the selection from the last dictation to
+     * the whole field, then put the caret back where the cycle started.
+     */
+    private void onSelectKey() {
+        InputConnection ic = getCurrentInputConnection();
+        if (ic == null) return;
+        caseCycleStep = 0;
+        if (selectionMode) {
+            // Also the way out of selection mode, so the key is never a dead end.
+            selectionMode = false;
+            updateEditingKeyTints();
+            return;
+        }
+
+        if (selectCycleStep == 0) selectCycleCaret = selStart;
+        selectCycleStep++;
+
+        if (selectCycleStep == 1) {
+            if (lastDictationStart >= 0 && lastDictationEnd > lastDictationStart) {
+                setSelectionTracked(ic, lastDictationStart, lastDictationEnd);
+                return;
+            }
+            // Nothing dictated into this field yet, so there is no first step.
+            selectCycleStep = 2;
+        }
+        if (selectCycleStep == 2) {
+            ic.performContextMenuAction(android.R.id.selectAll);
+            selectionChangePending = true;
+            return;
+        }
+        selectCycleStep = 0;
+        setSelectionTracked(ic, selectCycleCaret, selectCycleCaret);
+    }
+
+    /** Long-press on the select key: the cursor keys start selecting instead of moving. */
+    private void toggleSelectionMode() {
+        InputConnection ic = getCurrentInputConnection();
+        selectionMode = !selectionMode;
+        selectCycleStep = 0;
+        caseCycleStep = 0;
+        if (selectionMode) {
+            selectionAnchor = selStart;
+            if (ic != null && selStart != selEnd) {
+                setSelectionTracked(ic, selStart, selStart);
+            }
+        }
+        updateEditingKeyTints();
+    }
+
+    /**
+     * Case key: capitalized, then upper, then lower. Each step is derived from
+     * the text as it was before the cycle started — capitalizing text that is
+     * already uppercase would otherwise be a no-op. Does nothing without a
+     * selection.
+     */
+    private void onCaseKey() {
+        InputConnection ic = getCurrentInputConnection();
+        if (ic == null || selStart == selEnd) return;
+        CharSequence selected = ic.getSelectedText(0);
+        if (selected == null || selected.length() == 0) return;
+
+        if (caseCycleStep == 0) caseCycleOriginal = selected.toString();
+        caseCycleStep++;
+        String out;
+        if (caseCycleStep == 1) {
+            out = capitalizeWords(caseCycleOriginal);
+        } else if (caseCycleStep == 2) {
+            out = caseCycleOriginal.toUpperCase(Locale.getDefault());
+        } else {
+            out = caseCycleOriginal.toLowerCase(Locale.getDefault());
+            caseCycleStep = 0;
+        }
+
+        int start = Math.min(selStart, selEnd);
+        // commitText replaces the selection and leaves the caret after it, so the
+        // selection has to be restored for the next step of the cycle. Batched so
+        // the field doesn't flicker in between.
+        ic.beginBatchEdit();
+        ic.commitText(out, 1);
+        setSelectionTracked(ic, start, start + out.length());
+        ic.endBatchEdit();
+        updateEditingKeyTints();
+    }
+
+    private String capitalizeWords(String text) {
+        StringBuilder out = new StringBuilder(text.toLowerCase(Locale.getDefault()));
+        boolean atWordStart = true;
+        for (int i = 0; i < out.length(); i++) {
+            char c = out.charAt(i);
+            if (Character.isLetterOrDigit(c)) {
+                if (atWordStart) out.setCharAt(i, Character.toUpperCase(c));
+                atWordStart = false;
+            } else {
+                atWordStart = true;
+            }
+        }
+        return out.toString();
+    }
+
+    private void commitCharacter(String character) {
+        onTextEdited();
+        InputConnection ic = getCurrentInputConnection();
+        if (ic != null) ic.commitText(character, 1);
+    }
+
+    /**
+     * Any edit leaves the remembered offsets pointing at text that has moved, and
+     * ends the modes anchored to it — including selection mode, so a stray
+     * cursor key can't start selecting long after the user forgot it was on.
+     */
+    private void onTextEdited() {
+        lastDictationStart = -1;
+        lastDictationEnd = -1;
+        selectCycleStep = 0;
+        caseCycleStep = 0;
+        if (selectionMode) {
+            selectionMode = false;
+            updateEditingKeyTints();
+        }
+    }
+
+    /**
+     * Starts the editing keys over for a newly focused field: the cycles forget
+     * what they were doing, and the caret mirror adopts the offsets the editor
+     * reports for itself. Seeding it matters because onUpdateSelection is not
+     * guaranteed to arrive before the first key press — a WebView or a custom
+     * editor may never send one — and a key acting on the previous field's
+     * offsets would move the caret somewhere the user never was.
+     */
+    private void resetEditingState(EditorInfo attribute) {
+        selectionMode = false;
+        selectCycleStep = 0;
+        caseCycleStep = 0;
+        caseCycleOriginal = null;
+        lastDictationStart = -1;
+        lastDictationEnd = -1;
+        // EditorInfo reports -1 when it does not know where the caret is; the
+        // start of the field is the one offset that is valid in every field.
+        int start = attribute == null ? -1 : attribute.initialSelStart;
+        int end = attribute == null ? -1 : attribute.initialSelEnd;
+        if (start < 0 || end < 0) {
+            start = 0;
+            end = 0;
+        }
+        selStart = expectedSelStart = start;
+        selEnd = expectedSelEnd = end;
+        selectionChangePending = false;
+        updateEditingKeyTints();
+    }
+
+    /** Accents the keys whose behaviour is currently modified. */
+    private void updateEditingKeyTints() {
+        if (!viewEditRow) return;
+        tintKey(selectButton, selectionMode, true);
+        tintKey(wordLeftButton, selectionMode, false);
+        tintKey(charLeftButton, selectionMode, false);
+        tintKey(charRightButton, selectionMode, false);
+        tintKey(wordRightButton, selectionMode, false);
+        tintKey(shiftButton, caseCycleStep > 0, false);
+        // The bar under the arrow is the caps-lock convention, so it belongs to
+        // the all-uppercase step alone.
+        if (shiftButton instanceof android.widget.ImageView) {
+            ((android.widget.ImageView) shiftButton).setImageResource(
+                    caseCycleStep == 2 ? R.drawable.ic_shift_lock : R.drawable.ic_shift);
+        }
+    }
+
+    /** Tonal key state: {@code strong} is the primary pair the record button uses. */
+    private void tintKey(View key, boolean active, boolean strong) {
+        if (key == null) return;
+        int background;
+        int foreground;
+        if (!active) {
+            background = com.google.android.material.R.attr.colorSurfaceContainerHighest;
+            foreground = com.google.android.material.R.attr.colorOnSurfaceVariant;
+        } else if (strong) {
+            background = com.google.android.material.R.attr.colorPrimaryContainer;
+            foreground = com.google.android.material.R.attr.colorOnPrimaryContainer;
+        } else {
+            background = com.google.android.material.R.attr.colorSecondaryContainer;
+            foreground = com.google.android.material.R.attr.colorOnSecondaryContainer;
+        }
+        key.setBackgroundTintList(
+                ColorStateList.valueOf(MaterialColors.getColor(key, background)));
+        if (key instanceof android.widget.ImageView) {
+            ((android.widget.ImageView) key)
+                    .setColorFilter(MaterialColors.getColor(key, foreground));
+        }
+    }
+
     private boolean isPauseAudioEnabled() {
         return new File(getFilesDir(), "pause_audio").exists();
+    }
+
+    /**
+     * The status-row keyboard key. Implied by the editing keys, which need the
+     * bottom row for punctuation — so a marker pair left out of sync by an older
+     * install still produces a usable keyboard.
+     */
+    private boolean isKbKeyTopEnabled() {
+        return new File(getFilesDir(), "ime_kb_key_top").exists() || isEditRowEnabled();
+    }
+
+    private boolean isEditRowEnabled() {
+        return new File(getFilesDir(), "ime_edit_row").exists();
     }
 
     /** "Record in background" is default ON; the marker file is the opt-out. */

--- a/app/src/main/res/drawable/ic_cursor_left.xml
+++ b/app/src/main/res/drawable/ic_cursor_left.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15.41,7.41L14,6l-6,6 6,6 1.41,-1.41L10.83,12z" />
+</vector>

--- a/app/src/main/res/drawable/ic_cursor_right.xml
+++ b/app/src/main/res/drawable/ic_cursor_right.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10,6L8.59,7.41 13.17,12l-4.58,4.59L10,18l6,-6z" />
+</vector>

--- a/app/src/main/res/drawable/ic_keyboard.xml
+++ b/app/src/main/res/drawable/ic_keyboard.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20,5H4c-1.1,0 -1.99,0.9 -1.99,2L2,17c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V7c0,-1.1 -0.9,-2 -2,-2zM11,8h2v2h-2V8zM11,11h2v2h-2v-2zM8,8h2v2H8V8zM8,11h2v2H8v-2zM7,13H5v-2h2v2zM7,10H5V8h2v2zM16,17H8v-2h8v2zM16,13h-2v-2h2v2zM16,10h-2V8h2v2zM19,13h-2v-2h2v2zM19,10h-2V8h2v2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_select_all.xml
+++ b/app/src/main/res/drawable/ic_select_all.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,5h2V3c-1.1,0 -2,0.9 -2,2zM3,13h2v-2H3v2zM7,21h2v-2H7v2zM3,9h2V7H3v2zM13,3h-2v2h2V3zM19,3v2h2c0,-1.1 -0.9,-2 -2,-2zM5,21v-2H3c0,1.1 0.9,2 2,2zM3,17h2v-2H3v2zM9,3H7v2h2V3zM11,21h2v-2h-2v2zM19,13h2v-2h-2v2zM19,21c1.1,0 2,-0.9 2,-2h-2v2zM19,9h2V7h-2v2zM19,17h2v-2h-2v2zM15,21h2v-2h-2v2zM15,5h2V3h-2v2zM7,17h10V7H7v10zM9,9h6v6H9V9z" />
+</vector>

--- a/app/src/main/res/drawable/ic_shift.xml
+++ b/app/src/main/res/drawable/ic_shift.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,8.41L16.59,13 18,11.59l-6,-6 -6,6L7.41,13 12,8.41z" />
+</vector>

--- a/app/src/main/res/drawable/ic_shift_lock.xml
+++ b/app/src/main/res/drawable/ic_shift_lock.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,8.41L16.59,13 18,11.59l-6,-6 -6,6L7.41,13 12,8.41z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,18h12v-2H6v2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_word_left.xml
+++ b/app/src/main/res/drawable/ic_word_left.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M17.59,18L19,16.59 14.42,12 19,7.41 17.59,6l-6,6z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11,18l1.41,-1.41L7.83,12l4.58,-4.59L11,6l-6,6z" />
+</vector>

--- a/app/src/main/res/drawable/ic_word_right.xml
+++ b/app/src/main/res/drawable/ic_word_right.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6.41,6L5,7.41 9.58,12 5,16.59 6.41,18l6,-6z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M13,6l-1.41,1.41L16.17,12l-4.58,4.59L13,18l6,-6z" />
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -577,6 +577,78 @@
                             android:layout_height="wrap_content"/>
                     </LinearLayout>
 
+                    <!-- Keyboard-switch key in the status row -->
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:layout_marginTop="16dp">
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:orientation="vertical"
+                            android:layout_marginEnd="16dp">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/setting_ime_kb_key_top"
+                                android:textAppearance="?attr/textAppearanceBodyLarge"/>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/setting_ime_kb_key_top_desc"
+                                android:textAppearance="?attr/textAppearanceBodySmall"
+                                android:textColor="?attr/colorOnSurfaceVariant"
+                                android:layout_marginTop="2dp"/>
+                        </LinearLayout>
+
+                        <com.google.android.material.materialswitch.MaterialSwitch
+                            android:id="@+id/switch_ime_kb_key_top"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"/>
+                    </LinearLayout>
+
+                    <!-- Text editing keys on the voice keyboard -->
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:layout_marginTop="16dp">
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:orientation="vertical"
+                            android:layout_marginEnd="16dp">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/setting_ime_edit_row"
+                                android:textAppearance="?attr/textAppearanceBodyLarge"/>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/setting_ime_edit_row_desc"
+                                android:textAppearance="?attr/textAppearanceBodySmall"
+                                android:textColor="?attr/colorOnSurfaceVariant"
+                                android:layout_marginTop="2dp"/>
+                        </LinearLayout>
+
+                        <com.google.android.material.materialswitch.MaterialSwitch
+                            android:id="@+id/switch_ime_edit_row"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"/>
+                    </LinearLayout>
+
                     <!-- Subtitle line count -->
                     <LinearLayout
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/ime_layout.xml
+++ b/app/src/main/res/layout/ime_layout.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Voice keyboard. The text-editing keys and the status-row keyboard key are
+     opt-in (see the settings on the main screen): every view is inflated, and
+     RustInputMethodService hides the ones the user has not enabled. Keeping a
+     single layout means findViewById never returns null for a key that exists
+     in one arrangement but not the other. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -9,6 +14,7 @@
 
     <!-- Status row -->
     <LinearLayout
+        android:id="@+id/ime_status_row"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
@@ -19,7 +25,7 @@
             android:id="@+id/ime_status_text"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
+            android:layout_weight="2"
             android:text="Tap to speak"
             android:textColor="?attr/colorOnSurfaceVariant"
             android:textAppearance="?attr/textAppearanceBodyMedium"
@@ -31,9 +37,29 @@
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:visibility="gone"/>
+
+        <!-- Optional replacement for the bottom-row switch key: same action, but
+             out of thumb's way of the editing keys. Weight 1 against the status
+             text's 2 makes it a third of the row. -->
+        <ImageView
+            android:id="@+id/ime_switch_keyboard_top"
+            android:layout_width="0dp"
+            android:layout_height="44dp"
+            android:layout_weight="1"
+            android:src="@drawable/ic_keyboard"
+            android:scaleType="centerInside"
+            android:background="@drawable/bg_ime_key"
+            android:tint="?attr/colorOnSurfaceVariant"
+            android:clickable="true"
+            android:focusable="true"
+            android:layout_marginStart="8dp"
+            android:visibility="gone"
+            android:contentDescription="Switch keyboard"/>
     </LinearLayout>
 
-    <!-- Record area: pulsing mic-level glow behind a circular record button -->
+    <!-- Record area: pulsing mic-level glow behind a circular record button.
+         Shrinks when the optional rows are shown, so the keyboard keeps its
+         overall height instead of pushing the host app's layout around. -->
     <FrameLayout
         android:id="@+id/ime_record_container"
         android:layout_width="match_parent"
@@ -41,10 +67,14 @@
         android:clickable="true"
         android:focusable="true">
 
+        <!-- Follows the container so the glow is never clipped when the record
+             area shrinks to make room for the optional rows. At the default
+             200dp height this draws exactly as the old fixed 200dp square did:
+             the glow radius derives from min(width, height). -->
         <dev.notune.transcribe.MicLevelView
             android:id="@+id/ime_mic_level"
-            android:layout_width="200dp"
-            android:layout_height="200dp"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:layout_gravity="center"/>
 
         <View
@@ -73,8 +103,106 @@
             android:textAppearance="?attr/textAppearanceBodySmall"/>
     </FrameLayout>
 
-    <!-- Bottom key row -->
+    <!-- Optional cursor row: move and select without leaving the voice keyboard.
+         Long-pressing a word key jumps to the paragraph edge instead. -->
     <LinearLayout
+        android:id="@+id/ime_nav_row"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:baselineAligned="false"
+        android:paddingTop="8dp"
+        android:visibility="gone">
+
+        <ImageView
+            android:id="@+id/ime_shift"
+            android:layout_width="56dp"
+            android:layout_height="44dp"
+            android:src="@drawable/ic_shift"
+            android:scaleType="centerInside"
+            android:background="@drawable/bg_ime_key"
+            android:tint="?attr/colorOnSurfaceVariant"
+            android:clickable="true"
+            android:focusable="true"
+            android:layout_marginEnd="8dp"
+            android:contentDescription="Change case"/>
+
+        <ImageView
+            android:id="@+id/ime_word_left"
+            android:layout_width="0dp"
+            android:layout_height="44dp"
+            android:layout_weight="1"
+            android:src="@drawable/ic_word_left"
+            android:scaleType="centerInside"
+            android:background="@drawable/bg_ime_key"
+            android:tint="?attr/colorOnSurfaceVariant"
+            android:clickable="true"
+            android:focusable="true"
+            android:layout_marginEnd="8dp"
+            android:contentDescription="Previous word"/>
+
+        <ImageView
+            android:id="@+id/ime_char_left"
+            android:layout_width="0dp"
+            android:layout_height="44dp"
+            android:layout_weight="1"
+            android:src="@drawable/ic_cursor_left"
+            android:scaleType="centerInside"
+            android:background="@drawable/bg_ime_key"
+            android:tint="?attr/colorOnSurfaceVariant"
+            android:clickable="true"
+            android:focusable="true"
+            android:layout_marginEnd="8dp"
+            android:contentDescription="Move left"/>
+
+        <ImageView
+            android:id="@+id/ime_char_right"
+            android:layout_width="0dp"
+            android:layout_height="44dp"
+            android:layout_weight="1"
+            android:src="@drawable/ic_cursor_right"
+            android:scaleType="centerInside"
+            android:background="@drawable/bg_ime_key"
+            android:tint="?attr/colorOnSurfaceVariant"
+            android:clickable="true"
+            android:focusable="true"
+            android:layout_marginEnd="8dp"
+            android:contentDescription="Move right"/>
+
+        <ImageView
+            android:id="@+id/ime_word_right"
+            android:layout_width="0dp"
+            android:layout_height="44dp"
+            android:layout_weight="1"
+            android:src="@drawable/ic_word_right"
+            android:scaleType="centerInside"
+            android:background="@drawable/bg_ime_key"
+            android:tint="?attr/colorOnSurfaceVariant"
+            android:clickable="true"
+            android:focusable="true"
+            android:layout_marginEnd="8dp"
+            android:contentDescription="Next word"/>
+
+        <!-- Backspace lives here while the cursor row is shown; the bottom-row
+             one is hidden, so only ever one of the two is wired up. -->
+        <ImageView
+            android:id="@+id/ime_backspace_nav"
+            android:layout_width="56dp"
+            android:layout_height="44dp"
+            android:src="@drawable/ic_backspace"
+            android:scaleType="centerInside"
+            android:background="@drawable/bg_ime_key"
+            android:tint="?attr/colorOnSurfaceVariant"
+            android:clickable="true"
+            android:focusable="true"
+            android:contentDescription="Backspace"/>
+    </LinearLayout>
+
+    <!-- Bottom key row. Child order is chosen so that hiding a subset yields
+         either arrangement: switch/space/enter/backspace by default, or
+         select/comma/space/period/enter with the editing keys enabled. -->
+    <LinearLayout
+        android:id="@+id/ime_bottom_row"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
@@ -95,6 +223,52 @@
             android:contentDescription="Switch keyboard"/>
 
         <ImageView
+            android:id="@+id/ime_select"
+            android:layout_width="52dp"
+            android:layout_height="44dp"
+            android:src="@drawable/ic_select_all"
+            android:scaleType="centerInside"
+            android:background="@drawable/bg_ime_key"
+            android:tint="?attr/colorOnSurfaceVariant"
+            android:clickable="true"
+            android:focusable="true"
+            android:layout_marginEnd="8dp"
+            android:visibility="gone"
+            android:contentDescription="Select"/>
+
+        <!-- Comma and period carry their long-press character in the corner:
+             a hidden alternate nobody can see is a hidden alternate nobody uses. -->
+        <FrameLayout
+            android:id="@+id/ime_comma"
+            android:layout_width="40dp"
+            android:layout_height="44dp"
+            android:background="@drawable/bg_ime_key"
+            android:clickable="true"
+            android:focusable="true"
+            android:layout_marginEnd="8dp"
+            android:visibility="gone"
+            android:contentDescription="Comma">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text=","
+                android:textColor="?attr/colorOnSurfaceVariant"
+                android:textAppearance="?attr/textAppearanceTitleMedium"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="top|end"
+                android:layout_marginTop="4dp"
+                android:layout_marginEnd="6dp"
+                android:text="?"
+                android:textSize="11sp"
+                android:textColor="?attr/colorOnSurfaceVariant"/>
+        </FrameLayout>
+
+        <ImageView
             android:id="@+id/ime_space"
             android:layout_width="0dp"
             android:layout_height="44dp"
@@ -107,6 +281,36 @@
             android:focusable="true"
             android:layout_marginEnd="8dp"
             android:contentDescription="Space"/>
+
+        <FrameLayout
+            android:id="@+id/ime_period"
+            android:layout_width="40dp"
+            android:layout_height="44dp"
+            android:background="@drawable/bg_ime_key"
+            android:clickable="true"
+            android:focusable="true"
+            android:layout_marginEnd="8dp"
+            android:visibility="gone"
+            android:contentDescription="Period">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="."
+                android:textColor="?attr/colorOnSurfaceVariant"
+                android:textAppearance="?attr/textAppearanceTitleMedium"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="top|end"
+                android:layout_marginTop="4dp"
+                android:layout_marginEnd="6dp"
+                android:text="!"
+                android:textSize="11sp"
+                android:textColor="?attr/colorOnSurfaceVariant"/>
+        </FrameLayout>
 
         <ImageView
             android:id="@+id/ime_enter"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -37,6 +37,12 @@
     <string name="setting_auto_stop">Auto-Stopp bei Stille</string>
     <string name="setting_auto_stop_desc">Spracheingabe-Popup automatisch ~2 Sekunden nach dem Sprechende beenden</string>
 
+    <string name="setting_ime_kb_key_top">Tastaturtaste oben</string>
+    <string name="setting_ime_kb_key_top_desc">Die Tastaturwechsel-Taste der Sprachtastatur von der unteren Reihe in die Statuszeile verschieben</string>
+
+    <string name="setting_ime_edit_row">Textbearbeitungstasten</string>
+    <string name="setting_ime_edit_row_desc">Tasten für Cursor, Auswahl und Satzzeichen zur Sprachtastatur hinzufügen; erfordert die Tastaturtaste oben</string>
+
     <string name="setting_subtitle_lines">Untertitellänge</string>
     <string name="setting_subtitle_lines_desc">Wie viele Zeilen die Live-Untertitel anzeigen; älterer Text scrollt weg</string>
     <string name="subtitle_lines_2">2 Zeilen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -37,6 +37,12 @@
     <string name="setting_auto_stop">Parada automática tras silencio</string>
     <string name="setting_auto_stop_desc">Cerrar la ventana de entrada de voz automáticamente ~2 segundos después de dejar de hablar</string>
 
+    <string name="setting_ime_kb_key_top">Tecla de teclado arriba</string>
+    <string name="setting_ime_kb_key_top_desc">Mover la tecla de cambio de teclado del teclado de voz de la fila inferior a la barra de estado</string>
+
+    <string name="setting_ime_edit_row">Teclas de edición de texto</string>
+    <string name="setting_ime_edit_row_desc">Añadir teclas de cursor, selección y puntuación al teclado de voz; requiere la tecla de teclado arriba</string>
+
     <string name="setting_subtitle_lines">Longitud de subtítulos</string>
     <string name="setting_subtitle_lines_desc">Cuántas líneas muestran los subtítulos en directo; el texto antiguo se desplaza</string>
     <string name="subtitle_lines_2">2 líneas</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -37,6 +37,12 @@
     <string name="setting_auto_stop">Arrêt automatique après un silence</string>
     <string name="setting_auto_stop_desc">Fermer automatiquement la fenêtre de saisie vocale ~2 secondes après la fin de la parole</string>
 
+    <string name="setting_ime_kb_key_top">Touche clavier en haut</string>
+    <string name="setting_ime_kb_key_top_desc">Déplacer la touche de changement de clavier du clavier vocal de la rangée du bas vers la barre d\'état</string>
+
+    <string name="setting_ime_edit_row">Touches d\'édition de texte</string>
+    <string name="setting_ime_edit_row_desc">Ajouter des touches de curseur, de sélection et de ponctuation au clavier vocal ; nécessite la touche clavier en haut</string>
+
     <string name="setting_subtitle_lines">Longueur des sous-titres</string>
     <string name="setting_subtitle_lines_desc">Nombre de lignes affichées par les sous-titres en direct ; le texte plus ancien défile</string>
     <string name="subtitle_lines_2">2 lignes</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -37,6 +37,12 @@
     <string name="setting_auto_stop">Arresto automatico dopo il silenzio</string>
     <string name="setting_auto_stop_desc">Chiudi la finestra di immissione vocale automaticamente ~2 secondi dopo la fine del parlato</string>
 
+    <string name="setting_ime_kb_key_top">Tasto tastiera in alto</string>
+    <string name="setting_ime_kb_key_top_desc">Spostare il tasto di cambio tastiera della tastiera vocale dalla riga inferiore alla barra di stato</string>
+
+    <string name="setting_ime_edit_row">Tasti di modifica del testo</string>
+    <string name="setting_ime_edit_row_desc">Aggiungere tasti di cursore, selezione e punteggiatura alla tastiera vocale; richiede il tasto tastiera in alto</string>
+
     <string name="setting_subtitle_lines">Lunghezza sottotitoli</string>
     <string name="setting_subtitle_lines_desc">Quante righe mostrano i sottotitoli in tempo reale; il testo più vecchio scorre via</string>
     <string name="subtitle_lines_2">2 righe</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -37,6 +37,12 @@
     <string name="setting_auto_stop">Parada automática após silêncio</string>
     <string name="setting_auto_stop_desc">Fechar a janela de entrada de voz automaticamente ~2 segundos após você parar de falar</string>
 
+    <string name="setting_ime_kb_key_top">Tecla de teclado no topo</string>
+    <string name="setting_ime_kb_key_top_desc">Mover a tecla de troca de teclado do teclado de voz da linha inferior para a barra de status</string>
+
+    <string name="setting_ime_edit_row">Teclas de edição de texto</string>
+    <string name="setting_ime_edit_row_desc">Adicionar teclas de cursor, seleção e pontuação ao teclado de voz; requer a tecla de teclado no topo</string>
+
     <string name="setting_subtitle_lines">Comprimento das legendas</string>
     <string name="setting_subtitle_lines_desc">Quantas linhas as legendas ao vivo mostram; o texto mais antigo rola para fora</string>
     <string name="subtitle_lines_2">2 linhas</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -37,6 +37,12 @@
     <string name="setting_auto_stop">Автостоп при тишине</string>
     <string name="setting_auto_stop_desc">Автоматически закрывать окно голосового ввода примерно через 2 секунды после окончания речи</string>
 
+    <string name="setting_ime_kb_key_top">Клавиша клавиатуры сверху</string>
+    <string name="setting_ime_kb_key_top_desc">Переместить клавишу смены клавиатуры голосовой клавиатуры из нижнего ряда в строку состояния</string>
+
+    <string name="setting_ime_edit_row">Клавиши редактирования текста</string>
+    <string name="setting_ime_edit_row_desc">Добавить клавиши курсора, выделения и пунктуации на голосовую клавиатуру; требует клавишу клавиатуры сверху</string>
+
     <string name="setting_subtitle_lines">Длина субтитров</string>
     <string name="setting_subtitle_lines_desc">Сколько строк показывают субтитры; более старый текст прокручивается</string>
     <string name="subtitle_lines_2">2 строки</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,12 @@
     <string name="setting_auto_stop">Auto-stop after silence</string>
     <string name="setting_auto_stop_desc">End the voice input popup automatically ~2 seconds after you stop speaking</string>
 
+    <string name="setting_ime_kb_key_top">Keyboard key at the top</string>
+    <string name="setting_ime_kb_key_top_desc">Move the switch-keyboard key on the voice keyboard from the bottom row up to the status row</string>
+
+    <string name="setting_ime_edit_row">Text editing keys</string>
+    <string name="setting_ime_edit_row_desc">Add cursor, selection and punctuation keys to the voice keyboard; needs the keyboard key at the top</string>
+
     <string name="setting_subtitle_lines">Subtitle length</string>
     <string name="setting_subtitle_lines_desc">How many lines the live subtitles show; older text scrolls away</string>
     <string name="subtitle_lines_2">2 lines</string>


### PR DESCRIPTION
> [!NOTE]
> This was entirely vibe coded. I have used it daily for
> several weeks and verified the behaviour, but the code
> was not hand-written. 

Closes #103.
Supersedes #62 — see the note at the end.

### Features

Two settings, both off by default. With them off the keyboard is
unchanged.

- **Keyboard key at the top** — moves the switch-keyboard key from the
  bottom row up to the status row.
- **Text editing keys** — adds a cursor row and reworks the bottom row
  into cursor, selection, case and punctuation keys. It implies the
  setting above, since it needs the bottom row for punctuation. Both of them 
  mimic the Gboard layout. 

The keys: character and word cursor movement (long-press a word key to
jump to the paragraph edge), select, change case, comma and period with
their long-press alternates, space, enter and backspace.

### Code changes

- **`ime_layout.xml`** — every key is inflated in both arrangements and
  the service hides what the user has not enabled, so `findViewById`
  never returns null for a key that only exists in one of them.
- **`RustInputMethodService`** — the keys' behaviour, plus a mirror of
  the caret position kept in sync through `onUpdateSelection`.
- The optional rows take their height out of the record area rather than
  adding to it, so the keyboard does not grow and shove the host app's
  layout upward.
- Word boundaries use `java.text.BreakIterator`, so no new dependency.

### Notes

**Select and change case are cycles, not toggles.** Select goes last
dictation → whole field → back to where the caret was; case goes
capitalized → upper → lower. Each step is computed from the text as it
was when the cycle started, so capitalizing an already-uppercase word
still works. External caret movement resets both.

### On #62

This includes the same switch-key move as #62, reimplemented to coexist
with the editing row: instead of moving the view at runtime, the key
exists in both positions in the layout and visibility decides. It is also
translated into all seven locales. If you would rather take #62 as-is
first, say so and I will rebase this on top of it; otherwise I will close
#62 in favour of this.